### PR TITLE
Fix docker container bash not found error

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -169,7 +169,7 @@ RUN bash -c yarn install --dev
 # Document that we're going to expose port 3000
 EXPOSE 3000
 # Use Bash as the default command
-CMD ["/usr/bin/bash"]
+CMD ["/bin/bash"]
 
 ## Development
 FROM base AS development
@@ -244,4 +244,4 @@ WORKDIR /app
 # Document that we're going to expose port 3000
 EXPOSE 3000
 # Use Bash as the default command
-CMD ["/usr/bin/bash"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes an issue where Docker containers failed to start with an `exec: "/usr/bin/bash": stat /usr/bin/bash: no such file or directory: unknown` error. The base image `ghcr.io/forem/ruby:3.3.0` does not have `bash` at `/usr/bin/bash`. This PR updates the `CMD` instruction in `Dockerfile` and `Containerfile` to correctly point to `/bin/bash`, resolving the container startup failure.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

To test:
1. Build the Docker image (e.g., `docker build --pull --rm -f Dockerfile -t your-image-name:latest .`).
2. Run the container (e.g., `docker run --rm -it your-image-name:latest`).
3. Verify that the container starts successfully without the `/usr/bin/bash` error. For the default (development) stage, you might need to explicitly run a command like `docker run --rm -it your-image-name:latest /bin/bash` to get a shell, or `docker run --rm -p 3000:3000 your-image-name:latest bundle exec rails server -b 0.0.0.0 -p 3000` to start Rails.
4. To test the production stage, build with `--target production` and run; it should start Rails automatically.

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This change addresses a Docker image build/runtime issue. Verification involves successfully building and running the Docker container, which is not typically covered by automated unit/integration tests in the application's test suite.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)

---
<a href="https://cursor.com/background-agent?bcId=bc-74522a2b-3d03-486b-9766-e82afeb61d98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74522a2b-3d03-486b-9766-e82afeb61d98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

