### PR TITLE
Enhance JobPosts with structured fields, server-side JSON-LD, sitemap and UI updates

### DIFF
--- a/app/controllers/admin/job_posts_controller.rb
+++ b/app/controllers/admin/job_posts_controller.rb
@@ -8,6 +8,17 @@ module Admin
       post_type
       link
       color
+      category
+      organization_name
+      location
+      deadline_at
+      employment_type
+      salary_range
+      qualification
+      vacancies
+      source_name
+      source_url
+      important_dates
       published
       approved
       position

--- a/app/controllers/job_posts_controller.rb
+++ b/app/controllers/job_posts_controller.rb
@@ -1,6 +1,6 @@
 class JobPostsController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
-  before_action :set_job_post, only: %i[show edit update]
+  before_action :set_job_post, only: %i[edit update]
   after_action :verify_authorized, except: %i[index show]
 
   def index
@@ -39,17 +39,9 @@ class JobPostsController < ApplicationController
     end
   end
 
+
   def show
-    @job_post = JobPost.find_by!(slug: params[:slug] || params[:id])
-    return unless @job_post
-    
-    @related_jobs = @job_post.related_jobs
-    
-    # Only redirect if link is an absolute external URL
-    if @job_post.link.present? && @job_post.link.match?(/\Ahttps?:\/\//)
-      redirect_to @job_post.link, allow_other_host: true
-    end
-    # Otherwise render the show page (for relative URLs or no link)
+    @job_post = JobPost.available.find_by!(slug: params[:slug] || params[:id])
   end
 
   def new
@@ -94,19 +86,27 @@ class JobPostsController < ApplicationController
   end
 
   def job_post_params
-    params.require(:job_post).permit(:title, :post_type, :link, :color)
+    params.require(:job_post).permit(:title, :post_type, :category, :link, :color, :organization_name, :location,
+                                     :deadline_at, :employment_type, :salary_range, :qualification, :vacancies,
+                                     :source_name, :source_url, :important_dates)
   end
 
+
   def job_post_json(job_post)
-    link_url = job_post.link.presence || job_post_path(job_post.slug)
+    link_url = job_post.link.presence || job_posts_path
     link_url = link_url.start_with?('/') ? link_url : (link_url.start_with?('http') ? link_url : "/#{link_url}")
-    
+
     {
       id: job_post.id,
       title: job_post.title,
       link: link_url,
       badge_type: job_post.badge_type,
-      post_type: job_post.post_type
+      post_type: job_post.post_type,
+      organization_name: job_post.organization_name,
+      vacancies: job_post.vacancies,
+      salary_range: job_post.salary_range,
+      qualification: job_post.qualification&.truncate(80),
+      deadline_at: job_post.deadline_at&.to_date&.to_s
     }
   end
 end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -42,6 +42,9 @@ class SitemapsController < ApplicationController
       @tags = Tag.order("hotness_score DESC")
         .where(supported: true)
         .limit(RESULTS_LIMIT).offset(offset).pluck(:name, :updated_at)
+    when "jobs"
+      @jobs = JobPost.available.recent
+        .limit(RESULTS_LIMIT).offset(offset).pluck(:slug, :published_at)
     end
     set_surrogate_controls(Time.current)
     @view_template = resource
@@ -77,7 +80,7 @@ class SitemapsController < ApplicationController
   end
 
   def valid_resource_sitemap?
-    %w[posts users tags].include?(resource_string)
+    %w[posts users tags jobs].include?(resource_string)
   end
 
   def resource_string

--- a/app/models/job_post.rb
+++ b/app/models/job_post.rb
@@ -4,6 +4,8 @@ class JobPost < ApplicationRecord
   validates :title, presence: true
   validates :slug, presence: true, uniqueness: true
   validates :post_type, inclusion: { in: %w[new_update admit_card online_form] }, allow_nil: true
+  validates :employment_type, inclusion: { in: %w[full_time part_time contract internship temporary] }, allow_nil: true
+  validates :vacancies, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validates :link, presence: true, if: :published?
   validate :link_format, if: :published?
 
@@ -21,6 +23,7 @@ class JobPost < ApplicationRecord
   scope :approved, -> { where(approved: true) }
   scope :available, -> { published.approved }
   scope :by_post_type, ->(type) { where(post_type: type) }
+  scope :by_category, ->(category) { where(category: category) }
   scope :recent, -> { order(position: :asc, published_at: :desc, created_at: :desc) }
   scope :featured, -> { available.where(featured: true).recent.limit(8) }
   scope :pending_approval, -> { where(approved: false) }
@@ -46,6 +49,19 @@ class JobPost < ApplicationRecord
     # Last day badge: if there's a deadline and it's within 24 hours
     # Note: This assumes link might contain deadline info, or you can add a deadline_date field
     nil
+  end
+
+
+  def employment_type_schema_value
+    return nil if employment_type.blank?
+
+    {
+      "full_time" => "FULL_TIME",
+      "part_time" => "PART_TIME",
+      "contract" => "CONTRACTOR",
+      "internship" => "INTERN",
+      "temporary" => "TEMPORARY"
+    }[employment_type]
   end
 
   def related_jobs(limit: 4)

--- a/app/views/admin/job_posts/edit.html.erb
+++ b/app/views/admin/job_posts/edit.html.erb
@@ -42,6 +42,63 @@
     </div>
 
     <div class="form-group mb-4">
+      <%= form.label :organization_name, "Organization", class: "crayons-field__label" %>
+      <%= form.text_field :organization_name, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :location, "Location", class: "crayons-field__label" %>
+      <%= form.text_field :location, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :deadline_at, "Deadline", class: "crayons-field__label" %>
+      <%= form.datetime_local_field :deadline_at, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :employment_type, "Employment Type", class: "crayons-field__label" %>
+      <%= form.select :employment_type, options_for_select([
+        ["Select type...", ""],
+        ["Full time", "full_time"],
+        ["Part time", "part_time"],
+        ["Contract", "contract"],
+        ["Internship", "internship"],
+        ["Temporary", "temporary"]
+      ], @job_post.employment_type), {}, { class: "crayons-select" } %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :salary_range, "Salary Range", class: "crayons-field__label" %>
+      <%= form.text_field :salary_range, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :vacancies, "Vacancies", class: "crayons-field__label" %>
+      <%= form.number_field :vacancies, min: 1, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :qualification, "Eligibility / Qualification", class: "crayons-field__label" %>
+      <%= form.text_area :qualification, class: "crayons-textfield", rows: 3 %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :important_dates, "Important Dates", class: "crayons-field__label" %>
+      <%= form.text_area :important_dates, class: "crayons-textfield", rows: 3 %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :source_name, "Source Name", class: "crayons-field__label" %>
+      <%= form.text_field :source_name, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
+      <%= form.label :source_url, "Source URL", class: "crayons-field__label" %>
+      <%= form.url_field :source_url, class: "crayons-textfield" %>
+    </div>
+
+    <div class="form-group mb-4">
       <%= form.label :position, "Priority Position (lower numbers appear first)", class: "crayons-field__label" %>
       <%= form.number_field :position, min: 0, class: "crayons-textfield" %>
       <small class="color-secondary">Lower numbers appear first in listings.</small>

--- a/app/views/job_posts/edit.html.erb
+++ b/app/views/job_posts/edit.html.erb
@@ -40,6 +40,31 @@
         </div>
 
         <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :organization_name, "Organization", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.text_field :organization_name, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :location, "Location", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.text_field :location, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :deadline_at, "Deadline", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.datetime_local_field :deadline_at, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :employment_type, "Employment Type", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.select :employment_type, options_for_select([["Select type...", ""], ["Full time", "full_time"], ["Part time", "part_time"], ["Contract", "contract"], ["Internship", "internship"], ["Temporary", "temporary"]], @job_post.employment_type), {}, { style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" } %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :qualification, "Eligibility / Qualification", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.text_area :qualification, rows: 3, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
           <%= form.label :link, "Application/External Link *", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
           <%= form.url_field :link, required: true, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;", placeholder: "https://example.com/apply" %>
           <small style="color: #6b7280; font-size: 14px; margin-top: 4px; display: block;">This link will be used when users click on the job post.</small>
@@ -55,7 +80,7 @@
 
         <div class="form-actions" style="display: flex; gap: 12px; margin-top: 32px;">
           <%= form.submit "Update Job Post", class: "crayons-btn crayons-btn--primary", style: "padding: 12px 24px; font-size: 16px; font-weight: 600;" %>
-          <%= link_to "Cancel", job_post_path(@job_post), class: "crayons-btn crayons-btn--secondary", style: "padding: 12px 24px; font-size: 16px;" %>
+          <%= link_to "Cancel", job_posts_path, class: "crayons-btn crayons-btn--secondary", style: "padding: 12px 24px; font-size: 16px;" %>
         </div>
       <% end %>
     </div>

--- a/app/views/job_posts/index.html.erb
+++ b/app/views/job_posts/index.html.erb
@@ -8,6 +8,43 @@
   <meta property="og:url" content="<%= request.original_url %>">
 <% end %>
 
+<script type="application/ld+json">
+<%= raw({
+  "@context" => "https://schema.org",
+  "@type" => "CollectionPage",
+  "name" => "Latest Government Job Updates",
+  "url" => request.original_url,
+  "mainEntity" => {
+    "@type" => "ItemList",
+    "itemListElement" => (@new_updates + @admit_cards + @online_forms).each_with_index.map do |job_post, index|
+      job_url = job_post.link.presence || job_posts_url
+      job_url = job_url.start_with?("/") ? "#{request.base_url}#{job_url}" : job_url
+
+      {
+        "@type" => "ListItem",
+        "position" => index + 1,
+        "item" => {
+          "@type" => "JobPosting",
+          "title" => job_post.title,
+          "url" => job_url,
+          "datePosted" => (job_post.published_at || job_post.created_at)&.iso8601,
+          "hiringOrganization" => { "@type" => "Organization", "name" => job_post.organization_name.presence || Settings::Community.community_name },
+          "totalJobOpenings" => job_post.vacancies,
+          "validThrough" => job_post.deadline_at&.iso8601,
+          "employmentType" => job_post.employment_type_schema_value,
+          "jobLocationType" => (job_post.location.present? ? nil : "TELECOMMUTE"),
+          "applicantLocationRequirements" => (job_post.location.present? ? {
+            "@type" => "Country",
+            "name" => job_post.location
+          } : nil),
+          "baseSalary" => (job_post.salary_range.present? ? { "@type" => "MonetaryAmount", "value" => job_post.salary_range } : nil)
+        }.compact
+      }
+    end
+  }
+}.to_json) %>
+</script>
+
 <style>
   .jobs-page { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background: linear-gradient(135deg, #f5f7fa, #e3e8f5); color: #1a1a1a; line-height: 1.5; min-height: 100vh; }
   .jobs-container { max-width: 1200px; width: 90%; margin: 10px auto; padding: 10px; }
@@ -24,9 +61,6 @@
   .jobs-card li:hover { background: #f8f9fa; }
   .jobs-card a { color: #0056b3; text-decoration: none; font-size: 1em; transition: color .3s ease, padding-left .3s ease; display: block; }
   .jobs-card a:hover { color: #003d82; padding-left: 8px; }
-  .jobs-dynamic { background: linear-gradient(135deg, #fff, #f0f4ff); padding: 20px; border-radius: 12px; box-shadow: 0 6px 12px rgba(0,0,0,.05); margin-top: 20px; border-left: 5px solid #218838; }
-  .jobs-dynamic h3 { color: #218838; margin-bottom: 12px; font-size: 1.3em; font-weight: 700; text-transform: uppercase; }
-  .jobs-dynamic .meta { font-size: .9em; color: #666; font-style: italic; }
   .jobs-loading { text-align: center; color: #666; margin: 20px 0; font-size: 1.1em; display: none; }
   .load-more-btn { display: block; width: 100%; padding: 12px; margin-top: 15px; background: #0056b3; color: white; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; transition: background .3s ease; }
   .load-more-btn:hover { background: #003d82; }
@@ -41,7 +75,6 @@
     .jobs-grid { grid-template-columns: 1fr; }
     .jobs-btn { font-size: .9em; padding: 12px; }
     .jobs-card h2 { font-size: 1.2em; }
-    .jobs-dynamic h3 { font-size: 1.1em; }
   }
 </style>
 
@@ -50,20 +83,20 @@
     <div class="jobs-buttons">
       <% @featured_job_posts.each do |job_post| %>
         <% color = job_post.color.presence || "#0056b3" %>
-        <% link_url = job_post.link.presence || job_post_path(job_post.slug) %>
-        <% link_url = link_url.start_with?('/') ? link_url : (link_url.start_with?('http') ? link_url : "/#{link_url}") %>
-        <a href="<%= link_url %>" class="jobs-btn" style="background: <%= color %>">
+        <% featured_link = job_post.link.presence || job_posts_path %>
+        <% featured_link = featured_link.start_with?('/') ? featured_link : (featured_link.start_with?('http') ? featured_link : "/#{featured_link}") %>
+        <a href="<%= featured_link %>" class="jobs-btn" style="background: <%= color %>">
           <%= job_post.title %>
         </a>
       <% end %>
     </div>
 
     <div class="jobs-grid">
-      <section class="jobs-card" data-post-type="new_update">
-        <h2><i class="fas fa-bell"></i>New Update</h2>
+      <section id="new-update" class="jobs-card" data-post-type="new_update">
+        <h2><i class="fas fa-bell"></i>Result</h2>
         <ul id="new-updates-list">
           <% @new_updates.each do |job_post| %>
-            <% link_url = job_post.link.presence || job_post_path(job_post.slug) %>
+            <% link_url = job_post.link.presence || job_posts_path %>
             <% link_url = link_url.start_with?('/') ? link_url : (link_url.start_with?('http') ? link_url : "/#{link_url}") %>
             <li>
               <a href="<%= link_url %>" style="display: flex; align-items: center; gap: 8px;">
@@ -74,6 +107,19 @@
                   <span class="job-badge" style="background: #dc3545; color: white; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600;">LAST DAY</span>
                 <% end %>
               </a>
+              <% if job_post.vacancies.present? || job_post.qualification.present? || job_post.deadline_at.present? %>
+                <div class="meta" style="margin-top: 6px; font-size: 12px; color: #6b7280; display: flex; flex-wrap: wrap; gap: 8px;">
+                  <% if job_post.vacancies.present? %>
+                    <span><strong><%= t("views.job_posts.index.vacancies") %>:</strong> <%= job_post.vacancies %></span>
+                  <% end %>
+                  <% if job_post.qualification.present? %>
+                    <span><strong><%= t("views.job_posts.index.qualification") %>:</strong> <%= truncate(job_post.qualification, length: 80) %></span>
+                  <% end %>
+                  <% if job_post.deadline_at.present? %>
+                    <span><strong><%= t("views.job_posts.index.last_date") %>:</strong> <%= l(job_post.deadline_at.to_date) %></span>
+                  <% end %>
+                </div>
+              <% end %>
             </li>
           <% end %>
         </ul>
@@ -87,11 +133,11 @@
         </div>
       </section>
 
-      <section class="jobs-card" data-post-type="admit_card">
+      <section id="admit-card" class="jobs-card" data-post-type="admit_card">
         <h2><i class="fas fa-ticket-alt"></i>Admit Card</h2>
         <ul id="admit-cards-list">
           <% @admit_cards.each do |job_post| %>
-            <% link_url = job_post.link.presence || job_post_path(job_post.slug) %>
+            <% link_url = job_post.link.presence || job_posts_path %>
             <% link_url = link_url.start_with?('/') ? link_url : (link_url.start_with?('http') ? link_url : "/#{link_url}") %>
             <li>
               <a href="<%= link_url %>" style="display: flex; align-items: center; gap: 8px;">
@@ -102,6 +148,13 @@
                   <span class="job-badge" style="background: #dc3545; color: white; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600;">LAST DAY</span>
                 <% end %>
               </a>
+              <% if job_post.deadline_at.present? %>
+                <div class="meta" style="margin-top: 6px; font-size: 12px; color: #6b7280; display: flex; flex-wrap: wrap; gap: 8px;">
+                  <% if job_post.deadline_at.present? %>
+                    <span><strong><%= t("views.job_posts.index.exam_date") %>:</strong> <%= l(job_post.deadline_at.to_date) %></span>
+                  <% end %>
+                </div>
+              <% end %>
             </li>
           <% end %>
         </ul>
@@ -115,11 +168,11 @@
         </div>
       </section>
 
-      <section class="jobs-card" data-post-type="online_form">
+      <section id="top-online-form" class="jobs-card" data-post-type="online_form">
         <h2><i class="fas fa-file-alt"></i>Top Online Form</h2>
         <ul id="online-forms-list">
           <% @online_forms.each do |job_post| %>
-            <% link_url = job_post.link.presence || job_post_path(job_post.slug) %>
+            <% link_url = job_post.link.presence || job_posts_path %>
             <% link_url = link_url.start_with?('/') ? link_url : (link_url.start_with?('http') ? link_url : "/#{link_url}") %>
             <li>
               <a href="<%= link_url %>" style="display: flex; align-items: center; gap: 8px;">
@@ -130,6 +183,19 @@
                   <span class="job-badge" style="background: #dc3545; color: white; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600;">LAST DAY</span>
                 <% end %>
               </a>
+              <% if job_post.vacancies.present? || job_post.qualification.present? || job_post.deadline_at.present? %>
+                <div class="meta" style="margin-top: 6px; font-size: 12px; color: #6b7280; display: flex; flex-wrap: wrap; gap: 8px;">
+                  <% if job_post.vacancies.present? %>
+                    <span><strong><%= t("views.job_posts.index.vacancies") %>:</strong> <%= job_post.vacancies %></span>
+                  <% end %>
+                  <% if job_post.qualification.present? %>
+                    <span><strong><%= t("views.job_posts.index.qualification") %>:</strong> <%= truncate(job_post.qualification, length: 80) %></span>
+                  <% end %>
+                  <% if job_post.deadline_at.present? %>
+                    <span><strong><%= t("views.job_posts.index.last_date") %>:</strong> <%= l(job_post.deadline_at.to_date) %></span>
+                  <% end %>
+                </div>
+              <% end %>
             </li>
           <% end %>
         </ul>
@@ -144,13 +210,6 @@
       </section>
     </div>
 
-    <% if @featured_job_posts.present? %>
-      <div id="dynamic-posts" class="jobs-dynamic">
-        <h3>New Job Alert</h3>
-        <p>Stay tuned for the latest government job alerts across India.</p>
-        <div class="meta">Updated regularly</div>
-      </div>
-    <% end %>
 
     <% if user_signed_in? %>
       <div style="margin-top: 30px; text-align: right;">
@@ -161,34 +220,6 @@
 </main>
 
 <script>
-  // Schema.org structured data for SEO
-  (function() {
-    const jobPosts = <%= @featured_job_posts.map { |jp| { title: jp.title, link: jp.link.presence || job_post_path(jp.slug) } }.to_json.html_safe %>;
-    const schema = {
-      "@context": "https://schema.org",
-      "@type": "CollectionPage",
-      "name": "Latest Government Job Updates",
-      "description": "Discover the latest government job updates, admit cards, and online forms for 2025 across India",
-      "url": "<%= request.original_url %>",
-      "mainEntity": {
-        "@type": "ItemList",
-        "itemListElement": jobPosts.map((job, index) => ({
-          "@type": "ListItem",
-          "position": index + 1,
-          "item": {
-            "@type": "JobPosting",
-            "title": job.title,
-            "url": job.link
-          }
-        }))
-      }
-    };
-    const script = document.createElement('script');
-    script.type = 'application/ld+json';
-    script.text = JSON.stringify(schema);
-    document.head.appendChild(script);
-  })();
-
   // Load More functionality
   (function() {
     const loadMoreButtons = document.querySelectorAll('.load-more-btn');
@@ -228,7 +259,16 @@
             } else if (jobPost.badge_type === 'last_day') {
               badgeHtml = '<span class="job-badge" style="background: #dc3545; color: white; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600;">LAST DAY</span>';
             }
-            li.innerHTML = `<a href="${jobPost.link}" style="display: flex; align-items: center; gap: 8px;">${jobPost.title} ${badgeHtml}</a>`;
+            let metaHtml = '';
+            if (jobPost.post_type === 'admit_card' && jobPost.deadline_at) {
+              metaHtml = `<div class="meta" style="margin-top: 6px; font-size: 12px; color: #6b7280;"><span><strong>Exam Date:</strong> ${jobPost.deadline_at}</span></div>`;
+            } else if (jobPost.vacancies || jobPost.qualification || jobPost.deadline_at) {
+              const vacancyText = jobPost.vacancies ? `<span><strong>Total Posts:</strong> ${jobPost.vacancies}</span>` : '';
+              const qualificationText = jobPost.qualification ? `<span style="margin-left: 8px;"><strong>Qualification:</strong> ${jobPost.qualification}</span>` : '';
+              const deadlineText = jobPost.deadline_at ? `<span style="margin-left: 8px;"><strong>Last Date:</strong> ${jobPost.deadline_at}</span>` : '';
+              metaHtml = `<div class="meta" style="margin-top: 6px; font-size: 12px; color: #6b7280;">${vacancyText}${qualificationText}${deadlineText}</div>`;
+            }
+            li.innerHTML = `<a href="${jobPost.link}" style="display: flex; align-items: center; gap: 8px;">${jobPost.title} ${badgeHtml}</a>${metaHtml}`;
             list.appendChild(li);
           });
           

--- a/app/views/job_posts/new.html.erb
+++ b/app/views/job_posts/new.html.erb
@@ -35,6 +35,31 @@
         </div>
 
         <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :organization_name, "Organization", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.text_field :organization_name, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :location, "Location", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.text_field :location, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :deadline_at, "Deadline", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.datetime_local_field :deadline_at, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :employment_type, "Employment Type", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.select :employment_type, options_for_select([["Select type...", ""], ["Full time", "full_time"], ["Part time", "part_time"], ["Contract", "contract"], ["Internship", "internship"], ["Temporary", "temporary"]], @job_post.employment_type), {}, { style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" } %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
+          <%= form.label :qualification, "Eligibility / Qualification", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
+          <%= form.text_area :qualification, rows: 3, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;" %>
+        </div>
+
+        <div class="form-group" style="margin-bottom: 24px;">
           <%= form.label :link, "Application/External Link *", style: "display: block; margin-bottom: 8px; font-weight: 600; color: #374151;" %>
           <%= form.text_field :link, required: true, style: "width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 16px;", placeholder: "https://example.com/apply or /relative/path" %>
           <small style="color: #6b7280; font-size: 14px; margin-top: 4px; display: block;">This link will be used when users click on the job post. You can use absolute URLs (https://...) or relative paths (starting with /).</small>

--- a/app/views/job_posts/show.html.erb
+++ b/app/views/job_posts/show.html.erb
@@ -1,74 +1,39 @@
 <% content_for :title, @job_post.title %>
 <% content_for :page_meta do %>
-  <meta name="description" content="<%= @job_post.title %> - <%= @job_post.post_type&.humanize || 'Government Job' %>">
+  <meta name="description" content="<%= @job_post.title %>">
   <meta property="og:title" content="<%= @job_post.title %>">
-  <meta property="og:description" content="<%= @job_post.title %> - <%= @job_post.post_type&.humanize || 'Government Job' %>">
+  <meta property="og:description" content="<%= @job_post.title %>">
   <meta property="og:type" content="article">
   <meta property="og:url" content="<%= request.original_url %>">
 <% end %>
 
-<div class="crayons-layout">
-  <div class="crayons-layout__content">
-    <article class="job-post-detail" style="max-width: 1000px; margin: 0 auto; padding: 40px 20px;">
-      <header style="margin-bottom: 30px;">
-        <h1 style="font-size: 32px; font-weight: 700; margin-bottom: 16px; color: #1f2937;">
-          <%= @job_post.title %>
-        </h1>
-        <div class="job-post-meta" style="display: flex; gap: 20px; align-items: center; color: #6b7280; font-size: 14px; flex-wrap: wrap;">
-          <span>Posted by <%= @job_post.user.name %></span>
-          <% if @job_post.published_at %>
-            <span><%= @job_post.published_at.strftime("%B %d, %Y") %></span>
-          <% end %>
-          <% if @job_post.badge_type == 'new' %>
-            <span class="job-badge" style="background: #28a745; color: white; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600;">NEW</span>
-          <% end %>
-        </div>
-      </header>
+<main class="crayons-layout crayons-layout--limited-l">
+  <section class="crayons-card p-6">
+    <h1 class="crayons-title mb-4"><%= @job_post.title %></h1>
 
-      <div class="job-post-content" style="line-height: 1.8; color: #374151;">
-        <% if @job_post.link.present? %>
-          <% link_url = @job_post.link.start_with?('/') ? @job_post.link : (@job_post.link.start_with?('http') ? @job_post.link : "/#{@job_post.link}") %>
-          <div class="job-post-link" style="margin-top: 30px; padding: 20px; background-color: #f9fafb; border-radius: 8px; border-left: 4px solid #3b82f6;">
-            <p style="margin: 0 0 12px 0; font-weight: 600; color: #1f2937;">Application Link:</p>
-            <a href="<%= link_url %>" style="color: #3b82f6; text-decoration: none; font-size: 16px; word-break: break-all;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">
-              <%= @job_post.link %>
-            </a>
-          </div>
-        <% end %>
-      </div>
-
-      <% related_jobs = @job_post.related_jobs %>
-      <% if related_jobs.any? %>
-        <div class="related-jobs" style="margin-top: 50px; padding-top: 30px; border-top: 2px solid #e5e7eb;">
-          <h2 style="font-size: 24px; font-weight: 700; margin-bottom: 20px; color: #1f2937;">Related Jobs</h2>
-          <div class="related-jobs-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px;">
-            <% related_jobs.each do |related_job| %>
-              <% related_link = related_job.link.presence || job_post_path(related_job.slug) %>
-              <% related_link = related_link.start_with?('/') ? related_link : (related_link.start_with?('http') ? related_link : "/#{related_link}") %>
-              <div class="related-job-card" style="background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); transition: transform 0.2s;" onmouseover="this.style.transform='translateY(-4px)'" onmouseout="this.style.transform='translateY(0)'">
-                <a href="<%= related_link %>" style="text-decoration: none; color: inherit;">
-                  <h3 style="font-size: 18px; font-weight: 600; margin-bottom: 12px; color: #0056b3;"><%= related_job.title %></h3>
-                  <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
-                    <% if related_job.post_type.present? %>
-                      <span style="background: #e5e7eb; padding: 4px 10px; border-radius: 12px; font-size: 12px;"><%= related_job.post_type.humanize %></span>
-                    <% end %>
-                    <% if related_job.badge_type == 'new' %>
-                      <span class="job-badge" style="background: #28a745; color: white; padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600;">NEW</span>
-                    <% end %>
-                  </div>
-                </a>
-              </div>
-            <% end %>
-          </div>
-        </div>
+    <p class="color-secondary fs-s mb-4">
+      <% if @job_post.organization_name.present? %>
+        <strong><%= t("views.job_posts.index.organization") %>:</strong> <%= @job_post.organization_name %>
       <% end %>
-
-      <% if user_signed_in? && (current_user == @job_post.user || current_user.any_admin?) %>
-        <div class="job-post-actions" style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
-          <%= link_to "Edit", edit_job_post_path(@job_post.slug), class: "crayons-btn crayons-btn--secondary", style: "margin-right: 12px;" %>
-          <%= link_to "Back to Job Posts", job_posts_path, class: "crayons-btn crayons-btn--outlined" %>
-        </div>
+      <% if @job_post.published_at.present? %>
+        · <%= l(@job_post.published_at.to_date) %>
       <% end %>
-    </article>
-  </div>
-</div>
+    </p>
+
+    <% if @job_post.qualification.present? %>
+      <p class="mb-3"><strong><%= t("views.job_posts.index.qualification") %>:</strong> <%= @job_post.qualification %></p>
+    <% end %>
+
+    <% if @job_post.vacancies.present? %>
+      <p class="mb-3"><strong><%= t("views.job_posts.index.vacancies") %>:</strong> <%= @job_post.vacancies %></p>
+    <% end %>
+
+    <% if @job_post.deadline_at.present? %>
+      <p class="mb-5"><strong><%= t("views.job_posts.index.last_date") %>:</strong> <%= l(@job_post.deadline_at.to_date) %></p>
+    <% end %>
+
+    <% link_url = @job_post.link.start_with?('/') ? @job_post.link : (@job_post.link.start_with?('http') ? @job_post.link : "/#{@job_post.link}") %>
+    <%= link_to t("views.job_posts.show.application_link"), link_url, class: "crayons-btn crayons-btn--primary", rel: "nofollow" %>
+    <%= link_to t("views.job_posts.show.back"), job_posts_path, class: "crayons-btn crayons-btn--secondary ml-2" %>
+  </section>
+</main>

--- a/app/views/sitemaps/index.xml.erb
+++ b/app/views/sitemaps/index.xml.erb
@@ -17,4 +17,7 @@
   <sitemap>
       <loc><%= app_url("sitemap-tags.xml") %></loc>
   </sitemap>
+  <sitemap>
+      <loc><%= app_url("sitemap-jobs.xml") %></loc>
+  </sitemap>
 </sitemapindex>

--- a/app/views/sitemaps/jobs.xml.erb
+++ b/app/views/sitemaps/jobs.xml.erb
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <% @jobs.each do |slug, published_at| %>
+    <url>
+      <loc><%= app_url("/jobs/#{slug}") %></loc>
+      <lastmod><%= published_at.strftime("%F") %></lastmod>
+    </url>
+  <% end %>
+</urlset>

--- a/config/locales/views/job_posts/en.yml
+++ b/config/locales/views/job_posts/en.yml
@@ -1,0 +1,28 @@
+en:
+  views:
+    job_posts:
+      index:
+        organization: Organization
+        vacancies: Total Posts
+        salary: Salary
+        qualification: Qualification
+        exam_date: Exam Date
+        last_date: Last Date
+      show:
+        breadcrumb_home: Home
+        breadcrumb_jobs: Jobs
+        posted_by: "Posted by %{name}"
+        deadline: "Deadline: %{date}"
+        organization: Organization
+        location: Location
+        employment_type: Employment type
+        vacancies: Vacancies
+        salary_range: Salary range
+        category: Category
+        eligibility: Eligibility
+        important_dates: Important dates
+        application_link: Application Link
+        source: Source
+        related_jobs: Related Jobs
+        edit: Edit
+        back: Back to Job Posts

--- a/config/locales/views/job_posts/fr.yml
+++ b/config/locales/views/job_posts/fr.yml
@@ -1,0 +1,28 @@
+fr:
+  views:
+    job_posts:
+      index:
+        organization: Organisation
+        vacancies: Nombre de postes
+        salary: Salaire
+        qualification: Qualification
+        exam_date: Date d'examen
+        last_date: Date limite
+      show:
+        breadcrumb_home: Accueil
+        breadcrumb_jobs: Emplois
+        posted_by: "Publié par %{name}"
+        deadline: "Date limite : %{date}"
+        organization: Organisation
+        location: Lieu
+        employment_type: Type d'emploi
+        vacancies: Postes
+        salary_range: Salaire
+        category: Catégorie
+        eligibility: Éligibilité
+        important_dates: Dates importantes
+        application_link: Lien de candidature
+        source: Source
+        related_jobs: Emplois similaires
+        edit: Modifier
+        back: Retour aux offres

--- a/config/locales/views/job_posts/pt.yml
+++ b/config/locales/views/job_posts/pt.yml
@@ -1,0 +1,28 @@
+pt:
+  views:
+    job_posts:
+      index:
+        organization: Organização
+        vacancies: Total de vagas
+        salary: Salário
+        qualification: Qualificação
+        exam_date: Data do exame
+        last_date: Data limite
+      show:
+        breadcrumb_home: Início
+        breadcrumb_jobs: Vagas
+        posted_by: "Publicado por %{name}"
+        deadline: "Prazo: %{date}"
+        organization: Organização
+        location: Localização
+        employment_type: Tipo de emprego
+        vacancies: Vagas
+        salary_range: Faixa salarial
+        category: Categoria
+        eligibility: Elegibilidade
+        important_dates: Datas importantes
+        application_link: Link de candidatura
+        source: Fonte
+        related_jobs: Vagas relacionadas
+        edit: Editar
+        back: Voltar para vagas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,6 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
-  get 'job_posts/index'
-  get 'job_posts/show'
-  get 'job_posts/new'
-  get 'job_posts/create'
-  get 'job_posts/edit'
-  get 'job_posts/update'
   # Devise does not support scoping omniauth callbacks under a dynamic segment
   # so this lives outside our i18n scope.
   devise_for :users, controllers: {

--- a/db/migrate/20260225120000_add_structured_fields_to_job_posts.rb
+++ b/db/migrate/20260225120000_add_structured_fields_to_job_posts.rb
@@ -1,0 +1,15 @@
+class AddStructuredFieldsToJobPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :job_posts, :organization_name, :string
+    add_column :job_posts, :location, :string
+    add_column :job_posts, :deadline_at, :datetime
+    add_column :job_posts, :employment_type, :string
+    add_column :job_posts, :salary_range, :string
+    add_column :job_posts, :qualification, :text
+    add_column :job_posts, :vacancies, :integer
+    add_column :job_posts, :source_name, :string
+    add_column :job_posts, :source_url, :string
+    add_column :job_posts, :important_dates, :text
+
+  end
+end

--- a/db/migrate/20260225120500_add_indexes_for_job_posts_structured_fields.rb
+++ b/db/migrate/20260225120500_add_indexes_for_job_posts_structured_fields.rb
@@ -1,0 +1,8 @@
+class AddIndexesForJobPostsStructuredFields < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :job_posts, :deadline_at, algorithm: :concurrently
+    add_index :job_posts, :employment_type, algorithm: :concurrently
+  end
+end

--- a/docs/job_posts_feature_audit.md
+++ b/docs/job_posts_feature_audit.md
@@ -1,0 +1,89 @@
+# Job Posts Feature Audit: Critical Gaps and SEO/Engagement Improvements
+
+## Scope Reviewed
+- `JobPostsController`, model, routes, views, migration/schema state, and request specs.
+- Focus: crawlability, indexability, content quality, internal linking, and conversion/engagement signals.
+
+## Critical Gaps
+
+### 1) Job detail pages are often bypassed by server-side redirect
+In `show`, external links are redirected immediately (`redirect_to @job_post.link`) when the link is absolute. This prevents users and crawlers from consuming a rich on-site detail page, reducing page depth, dwell time, internal link opportunities, and long-tail ranking potential.
+
+### 2) Thin content model for ranking intent
+The model/migration contains only basic fields (`title`, `description`, `category`, `post_type`, `link`) and the public create/update controller permits only `title`, `post_type`, `link`, and `color`. Missing high-intent attributes (organization, location, eligibility, deadline, salary/grade, application dates, FAQ) make pages too thin for competitive SEO.
+
+### 3) Schema state appears out of sync for this feature
+`job_posts` migration exists with timestamp `20251210035211`, but `db/schema.rb` is at version `2026_02_19_204658` and does not define `job_posts`. This indicates the feature may not be represented in canonical schema state in this branch/environment, creating deployment and test confidence risk.
+
+### 4) Non-canonical/scaffold routes and weak tests
+Top-level legacy routes (`get 'job_posts/index'`, etc.) coexist with canonical `/jobs` resources, which can create duplicate entry points and unclear canonicalization. Request specs currently test scaffold endpoints only and assert `:success`, not business behavior, SEO metadata, redirects, or crawlable HTML content.
+
+### 5) Structured data is incomplete and client-injected
+Index page JSON-LD is injected via client JS and only includes title+url for featured posts. For best crawler reliability and eligibility, structured data should be rendered server-side and include richer properties (validThrough, datePosted, employmentType, hiringOrganization, jobLocation, etc.) where available.
+
+## High-Impact SEO Improvements
+
+1. **Stop auto-redirecting detail pages**
+   - Keep `/jobs/:slug` as first-class destination pages.
+   - Replace immediate redirect with prominent CTA button to external apply link (`rel="nofollow sponsored noopener"`, `target="_blank"`).
+   - Preserve internal content, related jobs, and metadata.
+
+2. **Expand job content schema and editorial surface**
+   - Add normalized fields: `organization_name`, `location`, `deadline_at`, `employment_type`, `salary_range`, `qualification`, `vacancies`, `source_name`, `source_url`, `important_dates`.
+   - Render this in structured sections (Overview, Eligibility, Dates, How to Apply).
+
+3. **Server-render JSON-LD for each job page**
+   - Emit `JobPosting` JSON-LD in `show` response HTML (not appended after page load in JS).
+   - Add `BreadcrumbList` JSON-LD for `/jobs` → post type → slug.
+
+4. **Canonical and robots hygiene**
+   - Add canonical tags on index/detail pages.
+   - Ensure only canonical `/jobs` routes are used; remove legacy scaffold routes.
+   - Add paginated rel links where relevant and ensure page-parameter handling is crawl-safe.
+
+5. **Programmatic internal linking strategy**
+   - Create crawlable post-type hubs (`/jobs/new_update`, `/jobs/admit_card`, `/jobs/online_form`) with unique intro copy.
+   - Add “related by exam/organization/category/deadline” blocks.
+   - Add “latest updates” widgets to high-traffic pages.
+
+## High-Impact Engagement & Traffic Improvements
+
+1. **SERP CTR optimization**
+   - Generate dynamic titles/meta descriptions by job attributes (org + exam + deadline + location + year).
+   - Add freshness indicators (updated date and status badges) in visible snippet text.
+
+2. **Retention loops**
+   - Add “follow category/exam” and “deadline reminder” (email/push) CTAs.
+   - Track reminder subscriptions and send pre-deadline nudges.
+
+3. **On-site UX for scan behavior**
+   - Add sticky “Apply Now” and “Save/Remind me” actions.
+   - Add quick facts panel above the fold and expandable detail sections below.
+
+4. **Measurement and experimentation**
+   - Define funnel events: listing impression → detail view → apply click.
+   - A/B test title templates, CTA placement, and related-job modules.
+
+## Prioritized Implementation Plan
+
+### Phase 1 (Immediate)
+- Remove auto-redirect in `show`; keep on-site detail page as canonical landing page.
+- Clean up duplicate scaffold routes.
+- Add regression request specs for canonical routes and metadata presence.
+
+### Phase 2 (Short-term)
+- Add core structured fields and render richer job detail content.
+- Implement server-side JSON-LD for `JobPosting` and breadcrumbs.
+- Improve internal linking with post-type/category hubs.
+
+### Phase 3 (Growth)
+- Build reminder/follow features and track conversion events.
+- Add automated SEO checks (presence of canonical, JSON-LD validity, title length guards).
+
+## Suggested KPIs
+- Organic sessions to `/jobs/*`
+- Indexed job-detail pages
+- CTR from search to job-detail pages
+- Detail page engagement time
+- Apply-link click-through rate
+- Return visits from reminder/follow flows

--- a/spec/factories/job_posts.rb
+++ b/spec/factories/job_posts.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :job_post do
+    association :user
+    sequence(:title) { |n| "Government Job Update #{n}" }
+    sequence(:slug) { |n| "government-job-update-#{n}" }
+    post_type { "new_update" }
+    link { "/jobs/test-application" }
+    published { true }
+    approved { true }
+    published_at { Time.current }
+    featured { false }
+    position { 0 }
+  end
+end

--- a/spec/requests/job_posts_spec.rb
+++ b/spec/requests/job_posts_spec.rb
@@ -1,46 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe "JobPosts", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/job_posts/index"
-      expect(response).to have_http_status(:success)
+  describe "GET /jobs" do
+    it "returns success and section entries link directly to application urls" do
+      create(:job_post, post_type: "new_update", link: "https://external.example/new-update", featured: false)
+      create(:job_post, post_type: "admit_card", link: "https://external.example/admit-card", featured: false)
+      create(:job_post, post_type: "online_form", link: "https://external.example/online-form", featured: false)
+
+      get job_posts_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Latest Government Job Updates - CareerPolitics")
+      expect(response.body).to include("Discover the latest government job updates")
+      expect(response.body).to include("https://external.example/new-update")
+      expect(response.body).to include("https://external.example/admit-card")
+      expect(response.body).to include("https://external.example/online-form")
+      expect(response.body).to include("Organization")
+      expect(response.body).to include("Total Posts")
+      expect(response.body).to include("Qualification")
+      expect(response.body).to include("Last Date")
+      expect(response.body).to include("Exam Date")
     end
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/job_posts/show"
-      expect(response).to have_http_status(:success)
+  describe "legacy scaffold routes" do
+    it "are no longer routable" do
+      expect(get: "/job_posts/index").not_to be_routable
+      expect(get: "/job_posts/show").not_to be_routable
+      expect(get: "/job_posts/new").not_to be_routable
+      expect(get: "/job_posts/create").not_to be_routable
+      expect(get: "/job_posts/edit").not_to be_routable
+      expect(get: "/job_posts/update").not_to be_routable
+      expect(get: "/jobs/type/new_update").not_to be_routable
     end
   end
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/job_posts/new"
-      expect(response).to have_http_status(:success)
+  describe "GET /jobs/:slug" do
+    it "renders a public job details page" do
+      job_post = create(:job_post, title: "Public role", slug: "public-role")
+
+      get job_post_path(job_post.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Public role")
+      expect(response.body).to include("Application Link")
     end
   end
-
-  describe "GET /create" do
-    it "returns http success" do
-      get "/job_posts/create"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/job_posts/edit"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /update" do
-    it "returns http success" do
-      get "/job_posts/update"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Sitemaps" do
         expect(response.body).to include("sitemap-posts.xml")
         expect(response.body).to include("sitemap-users.xml")
         expect(response.body).to include("sitemap-tags.xml")
+        expect(response.body).to include("sitemap-jobs.xml")
       end
 
       it "renders multiple posts pages if enough posts", :aggregate_failures do
@@ -161,6 +162,36 @@ RSpec.describe "Sitemaps" do
         get "/sitemap-users-2.xml"
         expect(response.body).not_to include(User.order("comments_count DESC").first.username)
         expect(response.body).not_to include(User.order("comments_count DESC").last.username)
+      end
+    end
+
+    context "with jobs in param" do
+      before do
+        create_list(:job_post, 8)
+      end
+
+      it "renders recent jobs if /sitemap-jobs", :aggregate_failures do
+        get "/sitemap-jobs.xml"
+        expect(response.body).to include(JobPost.recent.first.path)
+        expect(response.body).not_to include(JobPost.recent.last.path)
+      end
+
+      it "renders second page if /sitemap-jobs-1", :aggregate_failures do
+        get "/sitemap-jobs-1.xml"
+        expect(response.body).not_to include(JobPost.recent.first.path)
+        expect(response.body).to include(JobPost.recent.last.path)
+      end
+
+      it "renders first page if /sitemap-jobs-randomn0tnumber", :aggregate_failures do
+        get "/sitemap-jobs-randomn0tnumber.xml"
+        expect(response.body).to include(JobPost.recent.first.path)
+        expect(response.body).not_to include(JobPost.recent.last.path)
+      end
+
+      it "renders empty if /sitemap-jobs-2", :aggregate_failures do
+        get "/sitemap-jobs-2.xml"
+        expect(response.body).not_to include(JobPost.recent.first.path)
+        expect(response.body).not_to include(JobPost.recent.last.path)
       end
     end
   end

--- a/spec/views/job_posts/show.html.erb_spec.rb
+++ b/spec/views/job_posts/show.html.erb_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "job_posts/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
### Motivation
- Enrich the job posts content model and admin/editor surfaces so job detail pages are more useful for users and search engines. 
- Replace client-only structured data and shallow redirects with server-rendered JSON-LD and crawlable detail pages to improve SEO and indexing.
- Surface new attributes (organization, location, deadline, salary, vacancies, qualification, etc.) in listings, detail pages and sitemaps.
- Remove legacy scaffold routes to make canonical `/jobs` endpoints the primary surface.

### Description
- Added new DB columns via migrations `AddStructuredFieldsToJobPosts` and `AddIndexesForJobPostsStructuredFields` to store `organization_name`, `location`, `deadline_at`, `employment_type`, `salary_range`, `qualification`, `vacancies`, `source_name`, `source_url`, and `important_dates`, and added concurrent indexes on `deadline_at` and `employment_type`.
- Expanded `JobPost` model with validations for `employment_type` and `vacancies`, a `by_category` scope, and an `employment_type_schema_value` helper for schema mapping.
- Updated `JobPostsController` and `Admin::JobPostsController` to permit the new fields, changed `show` to serve `JobPost.available` (no immediate external redirect), adjusted JSON API output (`job_post_json`) to include new attributes, and refined link resolution to prefer application/featured listing paths for internal fallbacks.
- Server-rendered JSON-LD `JobPosting` added to the jobs index view and detail data surfaced across `index`, `show`, `new`, and `edit` views (admin and public) to display organization, vacancies, qualification, deadline, employment type, salary, and other fields; also updated client-side load-more logic to support the new meta fields.
- Added sitemap support for jobs: new `sitemaps/jobs.xml.erb`, included `sitemap-jobs.xml` in `sitemaps/index.xml.erb`, and validated sitemap controller logic and `valid_resource_sitemap?` to include `jobs`.
- Added locale files for job posts (`en`, `fr`, `pt`) and a factory `spec/factories/job_posts.rb`, updated request and sitemap specs to assert the new behavior and removed legacy scaffold routes from `routes.rb`.
- Added documentation audit `docs/job_posts_feature_audit.md` describing motivation and recommended SEO/UX changes.

### Testing
- Ran request specs covering jobs index and job detail behavior in `spec/requests/job_posts_spec.rb`, and sitemap specs in `spec/requests/sitemaps_spec.rb`; these tests exercised rendering of index content, JSON-LD presence indirectly via strings, legacy route non-routability, and job sitemap endpoints.
- The modified spec files executed as part of the test run and passed (no failing examples reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efeda8b14832688a15e3990d57c4e)