### PR TITLE
Add community bot AI post generation to scheduled automations

### DIFF
--- a/app/services/ai/community_bot_post_creator.rb
+++ b/app/services/ai/community_bot_post_creator.rb
@@ -1,11 +1,12 @@
 module Ai
   class CommunityBotPostCreator
-    VERSION = "1.0"
-    PostResult = Struct.new(:title, :body, keyword_init: true)
+    VERSION = "1.1"
+    PostResult = Struct.new(:title, :body, :tags, keyword_init: true)
 
-    def initialize(ai_context:, additional_instructions: nil, ai_client: nil)
+    def initialize(ai_context:, additional_instructions: nil, tags: nil, ai_client: nil)
       @ai_context = ai_context
       @additional_instructions = additional_instructions
+      @tags = normalize_tags(tags)
       @ai_client = ai_client || Ai::Base.new(wrapper: self)
     end
 
@@ -22,30 +23,33 @@ module Ai
 
     private
 
-    attr_reader :ai_context, :additional_instructions, :ai_client
+    attr_reader :ai_context, :additional_instructions, :tags, :ai_client
 
     def build_prompt
-      instructions_section = if additional_instructions.present?
-                               "\nAdditional instructions:\n#{additional_instructions.strip}\n"
-                             else
-                               ""
-                             end
+      additional_section = additional_instructions.present? ? "\nAdditional instructions:\n#{additional_instructions.strip}\n" : ""
+      tags_section = if tags.present?
+                       "Use these tags exactly (comma-separated): #{tags.join(', ')}"
+                     else
+                       "Generate 3-5 relevant tags (comma-separated) for the post"
+                     end
 
       <<~PROMPT
-        You are writing a post for a community bot.
+        You are writing a current-affairs post for a community bot.
 
-        Use the following AI context to generate a high-quality community post:
+        Use this AI context and focus on current affairs, recent developments, and timely relevance:
         #{ai_context}
-        #{instructions_section}
+        #{additional_section}
 
         Return your response in this exact format:
         TITLE: <post title>
+        TAGS: <comma-separated tags>
         BODY: <markdown body>
 
         Requirements:
-        - Keep the response concise, informative, and useful for the community.
+        - Keep the post concise, informative, and useful for the community.
         - BODY must be valid markdown.
-        - Do not include any extra wrapper text outside TITLE/BODY.
+        - #{tags_section}.
+        - Do not include any extra wrapper text outside TITLE/TAGS/BODY.
       PROMPT
     end
 
@@ -53,13 +57,23 @@ module Ai
       return if response.blank?
 
       title_match = response.match(/TITLE:\s*(.+?)(?:\n|$)/i)
+      tags_match = response.match(/TAGS:\s*(.+?)(?:\n|$)/i)
       body_match = response.match(/BODY:\s*(.+)/im)
 
       title = title_match ? title_match[1].strip : "Community Update"
       body = body_match ? body_match[1].strip : response.strip
       return if body.blank?
 
-      PostResult.new(title: title, body: body)
+      parsed_tags = normalize_tags(tags_match&.captures&.first)
+      parsed_tags = tags if parsed_tags.blank? && tags.present?
+
+      PostResult.new(title: title, body: body, tags: parsed_tags)
+    end
+
+    def normalize_tags(raw_tags)
+      return [] if raw_tags.blank?
+
+      raw_tags.to_s.split(",").map(&:strip).reject(&:blank?).uniq
     end
   end
 end

--- a/app/services/ai/community_bot_post_creator.rb
+++ b/app/services/ai/community_bot_post_creator.rb
@@ -1,13 +1,13 @@
 module Ai
   class CommunityBotPostCreator
-    VERSION = "1.1"
+    VERSION = "1.2"
     PostResult = Struct.new(:title, :body, :tags, keyword_init: true)
 
-    def initialize(ai_context:, additional_instructions: nil, tags: nil, ai_client: nil)
+    def initialize(ai_context:, additional_instructions: nil, tags: nil, ai_client: nil, affected_user: nil)
       @ai_context = ai_context
       @additional_instructions = additional_instructions
       @tags = normalize_tags(tags)
-      @ai_client = ai_client || Ai::Base.new(wrapper: self)
+      @ai_client = ai_client || Ai::Base.new(wrapper: self, affected_user: affected_user)
     end
 
     def generate
@@ -28,9 +28,9 @@ module Ai
     def build_prompt
       additional_section = additional_instructions.present? ? "\nAdditional instructions:\n#{additional_instructions.strip}\n" : ""
       tags_section = if tags.present?
-                       "Use these tags exactly (comma-separated): #{tags.join(', ')}"
+                       "Use these tags exactly (comma-separated, maximum 4 tags): #{tags.join(', ')}"
                      else
-                       "Generate 3-5 relevant tags (comma-separated) for the post"
+                       "Generate 1-4 relevant tags (comma-separated) for the post"
                      end
 
       <<~PROMPT
@@ -66,14 +66,27 @@ module Ai
 
       parsed_tags = normalize_tags(tags_match&.captures&.first)
       parsed_tags = tags if parsed_tags.blank? && tags.present?
+      parsed_tags = fallback_tags_from_context if parsed_tags.blank?
 
       PostResult.new(title: title, body: body, tags: parsed_tags)
+    end
+
+    def fallback_tags_from_context
+      context_tags = ai_context.to_s.downcase.scan(/\b[a-z0-9][a-z0-9-]{1,19}\b/)
+      stopwords = %w[about after among and are for from has have into not that the their them then they this was with your]
+      (context_tags - stopwords).uniq.first(4).presence || ["news"]
     end
 
     def normalize_tags(raw_tags)
       return [] if raw_tags.blank?
 
-      raw_tags.to_s.split(",").map(&:strip).reject(&:blank?).uniq
+      raw_tags
+        .to_s
+        .split(",")
+        .map { |tag| tag.strip.delete_prefix("#").downcase }
+        .reject(&:blank?)
+        .uniq
+        .first(4)
     end
   end
 end

--- a/app/services/ai/community_bot_post_creator.rb
+++ b/app/services/ai/community_bot_post_creator.rb
@@ -1,0 +1,65 @@
+module Ai
+  class CommunityBotPostCreator
+    VERSION = "1.0"
+    PostResult = Struct.new(:title, :body, keyword_init: true)
+
+    def initialize(ai_context:, additional_instructions: nil, ai_client: nil)
+      @ai_context = ai_context
+      @additional_instructions = additional_instructions
+      @ai_client = ai_client || Ai::Base.new(wrapper: self)
+    end
+
+    def generate
+      return if ai_context.blank?
+
+      response = ai_client.call(build_prompt)
+      parse_response(response)
+    rescue StandardError => e
+      Rails.logger.error("Community bot post generation failed: #{e.class} - #{e.message}")
+      Rails.logger.error(e.backtrace.join("\n"))
+      nil
+    end
+
+    private
+
+    attr_reader :ai_context, :additional_instructions, :ai_client
+
+    def build_prompt
+      instructions_section = if additional_instructions.present?
+                               "\nAdditional instructions:\n#{additional_instructions.strip}\n"
+                             else
+                               ""
+                             end
+
+      <<~PROMPT
+        You are writing a post for a community bot.
+
+        Use the following AI context to generate a high-quality community post:
+        #{ai_context}
+        #{instructions_section}
+
+        Return your response in this exact format:
+        TITLE: <post title>
+        BODY: <markdown body>
+
+        Requirements:
+        - Keep the response concise, informative, and useful for the community.
+        - BODY must be valid markdown.
+        - Do not include any extra wrapper text outside TITLE/BODY.
+      PROMPT
+    end
+
+    def parse_response(response)
+      return if response.blank?
+
+      title_match = response.match(/TITLE:\s*(.+?)(?:\n|$)/i)
+      body_match = response.match(/BODY:\s*(.+)/im)
+
+      title = title_match ? title_match[1].strip : "Community Update"
+      body = body_match ? body_match[1].strip : response.strip
+      return if body.blank?
+
+      PostResult.new(title: title, body: body)
+    end
+  end
+end

--- a/app/services/scheduled_automations/executor.rb
+++ b/app/services/scheduled_automations/executor.rb
@@ -95,6 +95,8 @@ module ScheduledAutomations
       case @automation.service_name
       when "github_repo_recap"
         call_github_repo_recap_service
+      when "community_bot_post_creator"
+        call_community_bot_post_creator_service
       else
         raise ArgumentError, "Unknown service: #{@automation.service_name}"
       end
@@ -129,6 +131,22 @@ module ScheduledAutomations
       end
 
       recap_result
+    end
+
+
+    def call_community_bot_post_creator_service
+      ai_context = @automation.action_config["ai_context"]
+
+      unless ai_context.present?
+        raise ArgumentError, "ai_context is required in action_config for community_bot_post_creator service"
+      end
+
+      service = Ai::CommunityBotPostCreator.new(
+        ai_context: ai_context,
+        additional_instructions: @automation.additional_instructions,
+      )
+
+      service.generate
     end
 
     def augment_with_instructions(body)

--- a/app/services/scheduled_automations/executor.rb
+++ b/app/services/scheduled_automations/executor.rb
@@ -78,8 +78,7 @@ module ScheduledAutomations
       rescue StandardError => e
         # Mark as failed and log error
         @automation.mark_as_failed!
-        Rails.logger.error("ScheduledAutomation ##{@automation.id} failed: #{e.class} - #{e.message}")
-        Rails.logger.error(e.backtrace.join("\n"))
+        log_automation_failure(e)
 
         Result.new(
           success?: false,
@@ -90,6 +89,27 @@ module ScheduledAutomations
     end
 
     private
+
+
+    def log_automation_failure(error)
+      Rails.logger.error("ScheduledAutomation ##{@automation.id} failed: #{error.class} - #{error.message}")
+      Rails.logger.error(error.backtrace.join("\n"))
+
+      AuditLog.create!(
+        user: @user,
+        category: "scheduled_automation.error",
+        slug: "scheduled_automation_failed",
+        data: {
+          automation_id: @automation.id,
+          service_name: @automation.service_name,
+          action: @automation.action,
+          error_class: error.class.to_s,
+          error_message: error.message,
+        },
+      )
+    rescue StandardError => log_error
+      Rails.logger.error("ScheduledAutomation ##{@automation.id} failed to persist audit log: #{log_error.class} - #{log_error.message}")
+    end
 
     def call_ai_service
       case @automation.service_name
@@ -145,6 +165,7 @@ module ScheduledAutomations
         ai_context: ai_context,
         additional_instructions: @automation.additional_instructions,
         tags: @automation.action_config["tags"],
+        affected_user: @user,
       )
 
       service.generate

--- a/app/services/scheduled_automations/executor.rb
+++ b/app/services/scheduled_automations/executor.rb
@@ -144,6 +144,7 @@ module ScheduledAutomations
       service = Ai::CommunityBotPostCreator.new(
         ai_context: ai_context,
         additional_instructions: @automation.additional_instructions,
+        tags: @automation.action_config["tags"],
       )
 
       service.generate
@@ -255,7 +256,7 @@ module ScheduledAutomations
       article.published_at = Time.current if published
 
       # Apply any additional article configuration
-      apply_article_config(article)
+      apply_article_config(article, service_result)
 
       # Save the article
       article.save!
@@ -263,12 +264,14 @@ module ScheduledAutomations
       article
     end
 
-    def apply_article_config(article)
+    def apply_article_config(article, service_result)
       config = @automation.action_config
 
-      # Set tags if specified
+      # Set tags from action config, otherwise fall back to service-generated tags
       if config["tags"].present?
         article.tag_list = config["tags"]
+      elsif service_result.respond_to?(:tags) && service_result.tags.present?
+        article.tag_list = service_result.tags
       end
 
       # Set organization if specified

--- a/app/views/admin/scheduled_automations/edit.html.erb
+++ b/app/views/admin/scheduled_automations/edit.html.erb
@@ -19,7 +19,7 @@
     <div class="mb-4">
       <label class="crayons-field__label" for="service_name">AI Service</label>
       <%= f.select :service_name, 
-          [["GitHub Repo Recap", "github_repo_recap"]], 
+          [["GitHub Repo Recap", "github_repo_recap"], ["Community Bot Post Creator", "community_bot_post_creator"]], 
           {},
           class: "crayons-select", 
           id: "service_name",
@@ -75,6 +75,17 @@
           <label class="crayons-field__label" for="tags">Tags (comma-separated)</label>
           <input type="text" name="scheduled_automation[action_config][tags]" id="tags" class="crayons-textfield" placeholder="opensource, github, recap" value="<%= @automation.action_config["tags"] %>">
           <p class="crayons-field__description">Optional tags to add to the generated article</p>
+        </div>
+      </div>
+
+      <!-- Community Bot Post Creator specific fields -->
+      <div id="community-bot-post-creator-fields" style="display: none;">
+        <h3 class="crayons-subtitle-2 mb-3">Community Bot Post Creator Configuration</h3>
+
+        <div class="mb-4">
+          <label class="crayons-field__label" for="ai_context">AI Context</label>
+          <textarea name="scheduled_automation[action_config][ai_context]" id="ai_context" class="crayons-textfield" rows="6" placeholder="Describe the context, topic, audience, and any required details for this post"><%= @automation.action_config["ai_context"] %></textarea>
+          <p class="crayons-field__description">Required context used by AI to generate the post content</p>
         </div>
       </div>
     </div>

--- a/app/views/admin/scheduled_automations/edit.html.erb
+++ b/app/views/admin/scheduled_automations/edit.html.erb
@@ -87,6 +87,12 @@
           <textarea name="scheduled_automation[action_config][ai_context]" id="ai_context" class="crayons-textfield" rows="6" placeholder="Describe the context, topic, audience, and any required details for this post"><%= @automation.action_config["ai_context"] %></textarea>
           <p class="crayons-field__description">Required context used by AI to generate the post content</p>
         </div>
+
+        <div class="mb-4">
+          <label class="crayons-field__label" for="community_bot_tags">Tags (comma-separated)</label>
+          <input type="text" name="scheduled_automation[action_config][tags]" id="community_bot_tags" class="crayons-textfield" placeholder="news, world, analysis" value="<%= @automation.action_config["tags"] %>">
+          <p class="crayons-field__description">Optional. If blank, AI will generate tags as part of the response.</p>
+        </div>
       </div>
     </div>
 

--- a/app/views/admin/scheduled_automations/new.html.erb
+++ b/app/views/admin/scheduled_automations/new.html.erb
@@ -87,6 +87,12 @@
           <textarea name="scheduled_automation[action_config][ai_context]" id="ai_context" class="crayons-textfield" rows="6" placeholder="Describe the context, topic, audience, and any required details for this post"><%= @automation.action_config["ai_context"] %></textarea>
           <p class="crayons-field__description">Required context used by AI to generate the post content</p>
         </div>
+
+        <div class="mb-4">
+          <label class="crayons-field__label" for="community_bot_tags">Tags (comma-separated)</label>
+          <input type="text" name="scheduled_automation[action_config][tags]" id="community_bot_tags" class="crayons-textfield" placeholder="news, world, analysis" value="<%= @automation.action_config["tags"] %>">
+          <p class="crayons-field__description">Optional. If blank, AI will generate tags as part of the response.</p>
+        </div>
       </div>
     </div>
 

--- a/app/views/admin/scheduled_automations/new.html.erb
+++ b/app/views/admin/scheduled_automations/new.html.erb
@@ -19,7 +19,7 @@
     <div class="mb-4">
       <label class="crayons-field__label" for="service_name">AI Service</label>
       <%= f.select :service_name, 
-          [["GitHub Repo Recap", "github_repo_recap"]], 
+          [["GitHub Repo Recap", "github_repo_recap"], ["Community Bot Post Creator", "community_bot_post_creator"]], 
           { prompt: "Select a service" },
           class: "crayons-select", 
           id: "service_name",
@@ -75,6 +75,17 @@
           <label class="crayons-field__label" for="tags">Tags (comma-separated)</label>
           <input type="text" name="scheduled_automation[action_config][tags]" id="tags" class="crayons-textfield" placeholder="opensource, github, recap">
           <p class="crayons-field__description">Optional tags to add to the generated article</p>
+        </div>
+      </div>
+
+      <!-- Community Bot Post Creator specific fields -->
+      <div id="community-bot-post-creator-fields" style="display: none;">
+        <h3 class="crayons-subtitle-2 mb-3">Community Bot Post Creator Configuration</h3>
+
+        <div class="mb-4">
+          <label class="crayons-field__label" for="ai_context">AI Context</label>
+          <textarea name="scheduled_automation[action_config][ai_context]" id="ai_context" class="crayons-textfield" rows="6" placeholder="Describe the context, topic, audience, and any required details for this post"><%= @automation.action_config["ai_context"] %></textarea>
+          <p class="crayons-field__description">Required context used by AI to generate the post content</p>
         </div>
       </div>
     </div>

--- a/spec/services/ai/community_bot_post_creator_spec.rb
+++ b/spec/services/ai/community_bot_post_creator_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Ai::CommunityBotPostCreator, type: :service do
+  let(:ai_client) { instance_double(Ai::Base) }
+  let(:ai_context) { "Create a weekly update for the Ruby on Rails community" }
+
+  describe "#generate" do
+    it "returns parsed title and body" do
+      response = "TITLE: Rails Weekly\nBODY: # This Week in Rails\nGreat updates!"
+      allow(ai_client).to receive(:call).and_return(response)
+
+      result = described_class.new(ai_context: ai_context, ai_client: ai_client).generate
+
+      expect(result.title).to eq("Rails Weekly")
+      expect(result.body).to eq("# This Week in Rails\nGreat updates!")
+    end
+
+    it "returns nil when context is blank" do
+      result = described_class.new(ai_context: "", ai_client: ai_client).generate
+      expect(result).to be_nil
+    end
+
+    it "adds additional instructions to the prompt" do
+      service = described_class.new(
+        ai_context: ai_context,
+        additional_instructions: "Target beginner developers",
+        ai_client: ai_client,
+      )
+
+      allow(ai_client).to receive(:call).with(include("Target beginner developers")).and_return("TITLE: T\nBODY: B")
+
+      service.generate
+    end
+  end
+end

--- a/spec/services/ai/community_bot_post_creator_spec.rb
+++ b/spec/services/ai/community_bot_post_creator_spec.rb
@@ -5,14 +5,24 @@ RSpec.describe Ai::CommunityBotPostCreator, type: :service do
   let(:ai_context) { "Create a weekly update for the Ruby on Rails community" }
 
   describe "#generate" do
-    it "returns parsed title and body" do
-      response = "TITLE: Rails Weekly\nBODY: # This Week in Rails\nGreat updates!"
+    it "returns parsed title, body, and tags" do
+      response = "TITLE: Rails Weekly\nTAGS: rails, ruby, testing\nBODY: # This Week in Rails\nGreat updates!"
       allow(ai_client).to receive(:call).and_return(response)
 
       result = described_class.new(ai_context: ai_context, ai_client: ai_client).generate
 
       expect(result.title).to eq("Rails Weekly")
       expect(result.body).to eq("# This Week in Rails\nGreat updates!")
+      expect(result.tags).to eq(%w[rails ruby testing])
+    end
+
+    it "falls back to provided tags when response tags are missing" do
+      response = "TITLE: Rails Weekly\nBODY: # This Week in Rails"
+      allow(ai_client).to receive(:call).and_return(response)
+
+      result = described_class.new(ai_context: ai_context, tags: "rails, ruby", ai_client: ai_client).generate
+
+      expect(result.tags).to eq(%w[rails ruby])
     end
 
     it "returns nil when context is blank" do
@@ -27,7 +37,15 @@ RSpec.describe Ai::CommunityBotPostCreator, type: :service do
         ai_client: ai_client,
       )
 
-      allow(ai_client).to receive(:call).with(include("Target beginner developers")).and_return("TITLE: T\nBODY: B")
+      allow(ai_client).to receive(:call).with(include("Target beginner developers")).and_return("TITLE: T\nTAGS: t\nBODY: B")
+
+      service.generate
+    end
+
+    it "requests generated tags when tags are not provided" do
+      service = described_class.new(ai_context: ai_context, ai_client: ai_client)
+
+      allow(ai_client).to receive(:call).with(include("Generate 3-5 relevant tags")).and_return("TITLE: T\nTAGS: t\nBODY: B")
 
       service.generate
     end

--- a/spec/services/ai/community_bot_post_creator_spec.rb
+++ b/spec/services/ai/community_bot_post_creator_spec.rb
@@ -45,9 +45,31 @@ RSpec.describe Ai::CommunityBotPostCreator, type: :service do
     it "requests generated tags when tags are not provided" do
       service = described_class.new(ai_context: ai_context, ai_client: ai_client)
 
-      allow(ai_client).to receive(:call).with(include("Generate 3-5 relevant tags")).and_return("TITLE: T\nTAGS: t\nBODY: B")
+      allow(ai_client).to receive(:call).with(include("Generate 1-4 relevant tags")).and_return("TITLE: T\nTAGS: t\nBODY: B")
 
       service.generate
     end
+
+    it "limits tags to 4 and normalizes formatting" do
+      response = "TITLE: T
+TAGS: #News, WORLD, analysis, policy, extra
+BODY: B"
+      allow(ai_client).to receive(:call).and_return(response)
+
+      result = described_class.new(ai_context: ai_context, ai_client: ai_client).generate
+
+      expect(result.tags).to eq(%w[news world analysis policy])
+    end
+
+    it "uses context-derived fallback tags when no tags are present" do
+      response = "TITLE: T
+BODY: B"
+      allow(ai_client).to receive(:call).and_return(response)
+
+      result = described_class.new(ai_context: "Global economy update for developers", ai_client: ai_client).generate
+
+      expect(result.tags).to be_present
+    end
+
   end
 end

--- a/spec/services/scheduled_automations/executor_spec.rb
+++ b/spec/services/scheduled_automations/executor_spec.rb
@@ -214,7 +214,9 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
 
 
     context "when service_name is community_bot_post_creator" do
-      let(:mock_post_result) { double("PostResult", title: "Community Update", body: "Generated post body") }
+      let(:mock_post_result) do
+        double("PostResult", title: "Community Update", body: "Generated post body", tags: ["news", "current-affairs"])
+      end
       let(:mock_post_service) { double("CommunityBotPostCreator", generate: mock_post_result) }
 
       before do
@@ -229,6 +231,7 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
         expect(Ai::CommunityBotPostCreator).to receive(:new).with(
           ai_context: "Write a post for our community about testing best practices",
           additional_instructions: automation.additional_instructions,
+          tags: automation.action_config["tags"],
         ).and_return(mock_post_service)
 
         executor.call
@@ -240,6 +243,25 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
         expect(result.success?).to be(true)
         expect(result.article.title).to eq("Community Update")
         expect(result.article.body_markdown).to eq("Generated post body")
+      end
+
+      it "applies generated tags when action_config tags are missing" do
+        result = executor.call
+
+        expect(result.article.tag_list).to eq(["news", "current-affairs"])
+      end
+
+      it "prefers configured tags over generated tags" do
+        automation.update!(
+          action_config: {
+            "ai_context" => "Write a post for our community about testing best practices",
+            "tags" => "configured, editorial"
+          },
+        )
+
+        result = executor.call
+
+        expect(result.article.tag_list).to eq(["configured", "editorial"])
       end
     end
 

--- a/spec/services/scheduled_automations/executor_spec.rb
+++ b/spec/services/scheduled_automations/executor_spec.rb
@@ -193,6 +193,14 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
         executor.call
         expect(automation.reload.state).to eq("failed")
       end
+      it "creates an audit log entry" do
+        expect { executor.call }.to change(AuditLog, :count).by(1)
+
+        log = AuditLog.last
+        expect(log.slug).to eq("scheduled_automation_failed")
+        expect(log.data["automation_id"]).to eq(automation.id)
+      end
+
 
       it "returns failure result" do
         result = executor.call
@@ -232,6 +240,7 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
           ai_context: "Write a post for our community about testing best practices",
           additional_instructions: automation.additional_instructions,
           tags: automation.action_config["tags"],
+          affected_user: bot,
         ).and_return(mock_post_service)
 
         executor.call

--- a/spec/services/scheduled_automations/executor_spec.rb
+++ b/spec/services/scheduled_automations/executor_spec.rb
@@ -212,6 +212,37 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
       end
     end
 
+
+    context "when service_name is community_bot_post_creator" do
+      let(:mock_post_result) { double("PostResult", title: "Community Update", body: "Generated post body") }
+      let(:mock_post_service) { double("CommunityBotPostCreator", generate: mock_post_result) }
+
+      before do
+        automation.update!(
+          service_name: "community_bot_post_creator",
+          action_config: { "ai_context" => "Write a post for our community about testing best practices" },
+        )
+        allow(Ai::CommunityBotPostCreator).to receive(:new).and_return(mock_post_service)
+      end
+
+      it "calls the community bot post creator service" do
+        expect(Ai::CommunityBotPostCreator).to receive(:new).with(
+          ai_context: "Write a post for our community about testing best practices",
+          additional_instructions: automation.additional_instructions,
+        ).and_return(mock_post_service)
+
+        executor.call
+      end
+
+      it "creates an article from the generated result" do
+        result = executor.call
+
+        expect(result.success?).to be(true)
+        expect(result.article.title).to eq("Community Update")
+        expect(result.article.body_markdown).to eq("Generated post body")
+      end
+    end
+
     context "when service_name is unknown" do
       before { automation.update!(service_name: "unknown_service") }
 
@@ -219,6 +250,20 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
         result = executor.call
         expect(result.success?).to be(false)
         expect(result.error_message).to include("Unknown service: unknown_service")
+      end
+    end
+
+
+    context "when ai_context is missing for community_bot_post_creator" do
+      before do
+        automation.update!(service_name: "community_bot_post_creator", action_config: {})
+      end
+
+      it "returns failure result" do
+        result = executor.call
+
+        expect(result.success?).to be(false)
+        expect(result.error_message).to include("ai_context is required")
       end
     end
 


### PR DESCRIPTION
### Motivation
- Enable community bots to generate context-driven posts via scheduled automations using the AI subsystem. 
- Keep the change focused and reusable by adding a dedicated AI service and wiring it into the existing `ScheduledAutomations::Executor` flow for draft/publish actions.

### Description
- Added a new AI service `Ai::CommunityBotPostCreator` that accepts `ai_context` and optional `additional_instructions` and returns a parsed `PostResult` with `title` and `body`.
- Extended `ScheduledAutomations::Executor` to support `service_name: "community_bot_post_creator"` and added `call_community_bot_post_creator_service` which validates `action_config["ai_context"]` and uses the new AI service.
- Updated admin scheduled automation forms (`app/views/admin/scheduled_automations/new.html.erb` and `edit.html.erb`) to expose the new service option and add an `AI Context` field for `action_config["ai_context"]`.
- Added regression specs: `spec/services/ai/community_bot_post_creator_spec.rb` and extended `spec/services/scheduled_automations/executor_spec.rb` to cover the new service integration and error handling.
- Note: new UI strings were added for the service and form labels; localization entries in `config/locales` were not included and should be added to satisfy i18n requirements.

### Testing
- Added RSpec tests for the new service (`spec/services/ai/community_bot_post_creator_spec.rb`) and executor integration (`spec/services/scheduled_automations/executor_spec.rb`).
- Attempted to run `bundle exec rspec spec/services/ai/community_bot_post_creator_spec.rb spec/services/scheduled_automations/executor_spec.rb`, but the command failed in this environment with `/bin/bash: line 1: bundle: command not found`; tests should pass locally or in CI where `bundle`/gems are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c6968a90832fa008776b45fceaa3)