### PR TITLE
Sanitize AI-generated trending tags before article creation

### DIFF
--- a/app/services/ai/community_bot_trending_article_creator.rb
+++ b/app/services/ai/community_bot_trending_article_creator.rb
@@ -549,7 +549,7 @@ module Ai
 
       seen = Set.new
       tags_array.filter_map do |tag|
-        normalized = tag.to_s.strip.downcase.gsub(/[^a-z0-9-]/, "")
+        normalized = tag.to_s.strip.downcase.gsub(/[^[:alnum:]]/, "")
         next if normalized.blank? || seen.include?(normalized)
 
         seen.add(normalized)

--- a/spec/services/ai/community_bot_trending_article_creator_spec.rb
+++ b/spec/services/ai/community_bot_trending_article_creator_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Ai::CommunityBotTrendingArticleCreator do
+  describe "#sanitize_tags" do
+    it "strips disallowed characters so generated tags pass article validations" do
+      service = described_class.new(ai_context: "Career platform")
+
+      sanitized_tags = service.send(:sanitize_tags, ["up-board-result", "career-guidance", "government-jobs", "result"])
+
+      expect(sanitized_tags).to eq(%w[upboardresult careerguidance governmentjobs result])
+      expect(Article.new(tag_list: sanitized_tags)).to be_valid
+    end
+  end
+
   describe "#generate" do
     let(:ai_client) { instance_double(Ai::Base) }
     let(:chrome_manager) { instance_double(TrendDiscovery::ChromeManager, start!: "http://selenium:4444/wd/hub", stop!: true) }


### PR DESCRIPTION
### Motivation
- Scheduled automation failed with `ActiveRecord::RecordInvalid` because AI-generated tags like `up-board-result` contain hyphens and other non-alphanumeric characters that violate Forem tag validation. 

### Description
- Tighten `Ai::CommunityBotTrendingArticleCreator#sanitize_tags` to strip all non-alphanumeric characters using `gsub(/[^[:alnum:]]/, "")` so tags conform to Forem validation. 
- Add a regression spec at `spec/services/ai/community_bot_trending_article_creator_spec.rb` that verifies hyphenated AI tags are normalized and that an `Article` built with the sanitized tags is valid.

### Testing
- Added an RSpec example `spec/services/ai/community_bot_trending_article_creator_spec.rb` to assert sanitization and `Article` validity (not executed here). 
- Attempted to run `bin/rspec spec/services/ai/community_bot_trending_article_creator_spec.rb` but the environment could not run the test suite (`/usr/bin/env: 'ruby': No such file or directory`), so tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1b6f6be4832f8347723712f03ab6)