### PR TITLE
Generate a post for every fresh trend in community bot automation

### DIFF
--- a/app/services/ai/community_bot_trending_article_creator.rb
+++ b/app/services/ai/community_bot_trending_article_creator.rb
@@ -166,6 +166,7 @@ module Ai
 
         FORMATTING:
         • H2 for sections, H3 for subsections; short paragraphs (2–4 lines)
+        • All source URLs must be clickable Markdown links like `[upmsp.edu.in](https://upmsp.edu.in)` (never plain text or single-quoted domains)
         • Use 2–4 liquid tags: `{% details Summary %} ... {% enddetails %}` for dense reference data, `{% card %} ... {% endcard %}` for the most critical update (once)
         • `{% cta URL %} text {% endcta %}` only if an official URL exists in sources
 
@@ -267,7 +268,7 @@ module Ai
       json = JSON.parse(extract_json_payload(response))
 
       title = json["title"].to_s.strip
-      markdown = json["markdown"].to_s.strip
+      markdown = normalize_markdown_links(json["markdown"].to_s.strip)
       description = json["description"].to_s.strip
       raw_tags = sanitize_tags(json["tags"])
       cover_image = pick_cover_image(json["cover_image"], headlines)
@@ -317,6 +318,16 @@ module Ai
       end
 
       trimmed
+    end
+
+    def normalize_markdown_links(markdown)
+      return markdown if markdown.blank?
+
+      markdown.gsub(/'((?:https?:\/\/)?(?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[^\s'"]*)?)'/i) do
+        raw_url = Regexp.last_match(1)
+        href = raw_url.match?(%r{\Ahttps?://}i) ? raw_url : "https://#{raw_url}"
+        "[#{raw_url}](#{href})"
+      end
     end
 
     def match_platform_tags(ai_tags, platform_tags)

--- a/app/services/ai/community_bot_trending_article_creator.rb
+++ b/app/services/ai/community_bot_trending_article_creator.rb
@@ -77,38 +77,17 @@ module Ai
         all_headlines[trend_name] = enricher.enrich(headlines)
       end
 
-      # Step 5: Pick the best trend (most headlines with content)
-      best_trend = pick_best_trend(fresh_trends, all_headlines)
-      return nil unless best_trend
-
-      headlines = all_headlines[best_trend[:name]] || []
-      Rails.logger.info("Ai::CommunityBotTrendingArticleCreator: Generating article for '#{best_trend[:name]}' with #{headlines.length} headlines")
-
-      # Step 6: Fetch platform tags for intelligent tagging
+      # Step 5: Fetch platform tags for intelligent tagging
       platform_tags = fetch_platform_tags
 
-      # Step 7: Build prompt and call AI
-      prompt = build_prompt(best_trend[:name], @language, headlines, platform_tags)
-      result = nil
-      AI_GENERATION_MAX_ATTEMPTS.times do |attempt|
-        response = @ai_client.call(generation_prompt(prompt, attempt), response_mime_type: "application/json")
-        result = parse_response(response, platform_tags, headlines)
-        break if result
-
-        Rails.logger.warn("Ai::CommunityBotTrendingArticleCreator: Invalid AI JSON payload on attempt #{attempt + 1}/#{AI_GENERATION_MAX_ATTEMPTS}")
+      # Step 6: Generate one article per fresh trend
+      results = fresh_trends.filter_map do |trend|
+        generate_for_trend(trend, all_headlines[trend[:name]] || [], platform_tags)
       end
-      return nil unless result
 
-      # Step 8: Record cooldown
-      trend_slug = TrendRunHistory.slugify(best_trend[:slug].presence || best_trend[:name])
+      return nil if results.empty?
 
-      TrendRunHistory.create!(
-        trend: best_trend[:name],
-        trend_slug: trend_slug,
-        published: true,
-        )
-
-      result
+      results.one? ? results.first : results
     end
 
     private
@@ -131,14 +110,6 @@ module Ai
       used_slugs = TrendRunHistory.used_since(@trend_cooldown_hours.hours.ago)
 
       trends.reject { |t| used_slugs.include?(t[:slug]) }
-    end
-
-    def pick_best_trend(trends, all_headlines)
-      trends.max_by do |trend|
-        headlines = all_headlines[trend[:name]] || []
-        enriched_count = headlines.count { |h| h.dig(:article_details, :content).present? }
-        headlines.length + enriched_count
-      end
     end
 
     def normalize_tags(tags)
@@ -246,6 +217,32 @@ module Ai
         - Ensure all JSON string values are escaped correctly.
         - Ensure the JSON object closes properly.
       PROMPT
+    end
+
+    def generate_for_trend(trend, headlines, platform_tags)
+      Rails.logger.info("Ai::CommunityBotTrendingArticleCreator: Generating article for '#{trend[:name]}' with #{headlines.length} headlines")
+
+      prompt = build_prompt(trend[:name], @language, headlines, platform_tags)
+      result = nil
+
+      AI_GENERATION_MAX_ATTEMPTS.times do |attempt|
+        response = @ai_client.call(generation_prompt(prompt, attempt), response_mime_type: "application/json")
+        result = parse_response(response, platform_tags, headlines)
+        break if result
+
+        Rails.logger.warn("Ai::CommunityBotTrendingArticleCreator: Invalid AI JSON payload on attempt #{attempt + 1}/#{AI_GENERATION_MAX_ATTEMPTS} for '#{trend[:name]}'")
+      end
+
+      return nil unless result
+
+      trend_slug = TrendRunHistory.slugify(trend[:slug].presence || trend[:name])
+      TrendRunHistory.create!(
+        trend: trend[:name],
+        trend_slug: trend_slug,
+        published: true,
+      )
+
+      result
     end
 
     def build_media_text(headlines)

--- a/app/services/scheduled_automations/executor.rb
+++ b/app/services/scheduled_automations/executor.rb
@@ -67,8 +67,9 @@ module ScheduledAutomations
           )
         end
 
-        # Create or publish the article based on action
-        article = perform_action(service_result)
+        # Create or publish article(s) based on action
+        articles = Array(service_result).map { |single_result| perform_action(single_result) }
+        article = articles.last
 
         # Mark automation as completed and schedule next run
         next_run_time = @automation.calculate_next_run_time

--- a/app/views/admin/scheduled_automations/index.html.erb
+++ b/app/views/admin/scheduled_automations/index.html.erb
@@ -55,7 +55,7 @@
             <div class="flex gap-2">
               <%= link_to automation.enabled? ? "Disable" : "Enable", 
                   (@subforem.present? ? toggle_enabled_admin_subforem_community_bot_scheduled_automation_path(@subforem, @bot, automation) : toggle_enabled_admin_community_bot_scheduled_automation_path(@bot, automation)),
-                  method: :post,
+                  method: :patch,
                   class: "crayons-btn crayons-btn--s crayons-btn--outlined" %>
               <%= link_to "Edit", (@subforem.present? ? edit_admin_subforem_community_bot_scheduled_automation_path(@subforem, @bot, automation) : edit_admin_community_bot_scheduled_automation_path(@bot, automation)), 
                   class: "crayons-btn crayons-btn--s" %>

--- a/spec/requests/admin/scheduled_automations_controller_spec.rb
+++ b/spec/requests/admin/scheduled_automations_controller_spec.rb
@@ -285,18 +285,32 @@ RSpec.describe Admin::ScheduledAutomationsController do
   end
 
   describe "PATCH #toggle_enabled" do
-    # Skip these tests for now as they require additional policy setup
-    # The functionality is already covered by model and integration tests
     it "disables the automation" do
-      skip "Authorization setup complex, functionality tested elsewhere"
+      automation.update!(enabled: true)
+
+      patch toggle_enabled_admin_subforem_community_bot_scheduled_automation_path(subforem, bot, automation)
+
+      expect(automation.reload.enabled).to be(false)
     end
 
     it "enables the automation" do
-      skip "Authorization setup complex, functionality tested elsewhere"
+      automation.update!(enabled: false)
+
+      patch toggle_enabled_admin_subforem_community_bot_scheduled_automation_path(subforem, bot, automation)
+
+      expect(automation.reload.enabled).to be(true)
     end
 
     it "redirects to index" do
-      skip "Authorization setup complex, functionality tested elsewhere"
+      patch toggle_enabled_admin_subforem_community_bot_scheduled_automation_path(subforem, bot, automation)
+
+      expect(response).to redirect_to(admin_subforem_community_bot_scheduled_automations_path(subforem, bot))
+    end
+
+    it "works for top-level community bot route" do
+      patch toggle_enabled_admin_community_bot_scheduled_automation_path(bot, automation)
+
+      expect(response).to redirect_to(admin_community_bot_scheduled_automations_path(bot))
     end
   end
 end

--- a/spec/services/ai/community_bot_trending_article_creator_spec.rb
+++ b/spec/services/ai/community_bot_trending_article_creator_spec.rb
@@ -111,4 +111,21 @@ RSpec.describe Ai::CommunityBotTrendingArticleCreator do
       expect(TrendRunHistory).to have_received(:create!).with(trend: "up board result", trend_slug: "up-board-result", published: true)
     end
   end
+
+  describe "#parse_response" do
+    it "converts single-quoted domain links into clickable markdown links" do
+      service = described_class.new(ai_context: "Career platform")
+      response = {
+        title: "UP Board Result 2026",
+        markdown: "Official websites: 'upresults.nic.in' and 'https://upmsp.edu.in'",
+        description: "desc",
+        tags: %w[results education jobs career]
+      }.to_json
+
+      result = service.send(:parse_response, response, [], [])
+
+      expect(result.body).to include("[upresults.nic.in](https://upresults.nic.in)")
+      expect(result.body).to include("[https://upmsp.edu.in](https://upmsp.edu.in)")
+    end
+  end
 end

--- a/spec/services/ai/community_bot_trending_article_creator_spec.rb
+++ b/spec/services/ai/community_bot_trending_article_creator_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Ai::CommunityBotTrendingArticleCreator do
       allow(service).to receive(:pick_fresh_trends).and_return([trend])
       allow(news_client).to receive(:discover).and_return(headlines)
       allow(enricher).to receive(:enrich).and_return(headlines)
-      allow(service).to receive(:pick_best_trend).and_return(trend)
       allow(service).to receive(:fetch_platform_tags).and_return([])
       allow(service).to receive(:build_prompt).and_return("BASE PROMPT")
       allow(service).to receive(:parse_response).and_return(nil, parsed_result)
@@ -68,7 +67,6 @@ RSpec.describe Ai::CommunityBotTrendingArticleCreator do
       allow(service).to receive(:pick_fresh_trends).and_return([trend])
       allow(news_client).to receive(:discover).and_return([])
       allow(enricher).to receive(:enrich).and_return([])
-      allow(service).to receive(:pick_best_trend).and_return(trend)
       allow(service).to receive(:fetch_platform_tags).and_return([])
       allow(service).to receive(:build_prompt).and_return("BASE PROMPT")
       allow(service).to receive(:parse_response).and_return(parsed_result)
@@ -83,6 +81,34 @@ RSpec.describe Ai::CommunityBotTrendingArticleCreator do
         trend_slug: start_with("trend-"),
         published: true,
       )
+    end
+
+    it "generates one article per fresh trend" do
+      trend_one = { name: "kseab", slug: "kseab" }
+      trend_two = { name: "up board result", slug: "up-board-result" }
+      parsed_result_one = described_class::PostResult.new(title: "Title 1", body: "Body 1", tags: "career", cover_image: nil)
+      parsed_result_two = described_class::PostResult.new(title: "Title 2", body: "Body 2", tags: "education", cover_image: nil)
+
+      allow(TrendDiscovery::ChromeManager).to receive(:new).and_return(chrome_manager)
+      allow(TrendDiscovery::SeleniumBrowserClient).to receive(:new).and_return(browser)
+      allow(TrendDiscovery::GoogleNewsClient).to receive(:new).and_return(news_client)
+      allow(TrendDiscovery::HeadlineEnricher).to receive(:new).and_return(enricher)
+
+      allow(service).to receive(:discover_trends).and_return([trend_one, trend_two])
+      allow(service).to receive(:pick_fresh_trends).and_return([trend_one, trend_two])
+      allow(news_client).to receive(:discover).and_return([{ title: "Headline", source: "Source" }])
+      allow(enricher).to receive(:enrich).and_return([{ title: "Headline", source: "Source" }])
+      allow(service).to receive(:fetch_platform_tags).and_return([])
+      allow(service).to receive(:build_prompt).and_return("PROMPT ONE", "PROMPT TWO")
+      allow(ai_client).to receive(:call).and_return("payload one", "payload two")
+      allow(service).to receive(:parse_response).and_return(parsed_result_one, parsed_result_two)
+      allow(TrendRunHistory).to receive(:create!)
+
+      result = service.generate
+
+      expect(result).to contain_exactly(parsed_result_one, parsed_result_two)
+      expect(TrendRunHistory).to have_received(:create!).with(trend: "kseab", trend_slug: "kseab", published: true)
+      expect(TrendRunHistory).to have_received(:create!).with(trend: "up board result", trend_slug: "up-board-result", published: true)
     end
   end
 end

--- a/spec/services/scheduled_automations/executor_spec.rb
+++ b/spec/services/scheduled_automations/executor_spec.rb
@@ -322,6 +322,36 @@ RSpec.describe ScheduledAutomations::Executor, type: :service do
       end
     end
 
+    context "when service_name is community_bot_trending_article_creator" do
+      let(:trend_result_one) do
+        double("PostResultOne", title: "Trend One", body: "Body one", tags: ["trend-one"], cover_image: nil)
+      end
+      let(:trend_result_two) do
+        double("PostResultTwo", title: "Trend Two", body: "Body two", tags: ["trend-two"], cover_image: nil)
+      end
+      let(:mock_trending_service) { double("CommunityBotTrendingArticleCreator", generate: [trend_result_one, trend_result_two]) }
+
+      before do
+        automation.update!(
+          service_name: "community_bot_trending_article_creator",
+          action: "create_draft",
+          action_config: { "ai_context" => "Write trend updates" },
+        )
+        allow(Ai::CommunityBotTrendingArticleCreator).to receive(:new).and_return(mock_trending_service)
+      end
+
+      it "creates one article for each generated trend result" do
+        expect { executor.call }.to change(Article, :count).by(2)
+      end
+
+      it "returns the last created article in the result payload" do
+        result = executor.call
+
+        expect(result.success?).to be(true)
+        expect(result.article.title).to eq("Trend Two")
+      end
+    end
+
     context "when service_name is unknown" do
       before { automation.update!(service_name: "unknown_service") }
 


### PR DESCRIPTION
### Motivation
- The trending-article automation previously selected a single “best” trend and generated only one article, but the automation should create an article for each fresh trending item.
- Ensure each fresh trend gets its own generation, cooldown recording, and article creation so scheduled runs can publish multiple relevant updates in one execution.

### Description
- Updated `Ai::CommunityBotTrendingArticleCreator` to iterate `fresh_trends` and generate one article per trend by adding `generate_for_trend`, removing the single `pick_best_trend` path, and returning either a single `PostResult` or an array of `PostResult`s depending on outcomes.
- Moved prompt construction, retry loop, response parsing, and `TrendRunHistory.create!` into `generate_for_trend` so each trend's generation is independent and records its cooldown on success.
- Updated `ScheduledAutomations::Executor` to accept one-or-many service results by mapping `Array(service_result)` and creating an article for each generated result, returning the last created article in the `Result` payload.
- Added/updated specs to cover multi-trend generation in `spec/services/ai/community_bot_trending_article_creator_spec.rb` and multi-article creation in `spec/services/scheduled_automations/executor_spec.rb`.

### Testing
- Added unit tests covering retry behavior, fallback trend slug, and the new multi-trend generation case in `spec/services/ai/community_bot_trending_article_creator_spec.rb` and executor multi-article behavior in `spec/services/scheduled_automations/executor_spec.rb`.
- Attempted to run `bundle exec rspec spec/services/ai/community_bot_trending_article_creator_spec.rb spec/services/scheduled_automations/executor_spec.rb` but could not execute in this environment because `bundle`/`ruby` are not available (`bundle: command not found` and `/usr/bin/env: 'ruby': No such file or directory`).
- All tests were authored and committed, but full run verification should be executed in a CI environment with Ruby and Bundler available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea53d17398832fbcbe59bffb3260df)