### PR TITLE
Update db/schema.rb to include trend_run_histories migration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_19_073000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1687,6 +1687,16 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
     t.index ["social_preview_template"], name: "index_tags_on_social_preview_template"
     t.index ["supported"], name: "index_tags_on_supported"
     t.index ["taggings_count"], name: "index_tags_on_taggings_count"
+  end
+
+  create_table "trend_run_histories", force: :cascade do |t|
+    t.string "trend", null: false
+    t.string "trend_slug", null: false
+    t.boolean "published", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_trend_run_histories_on_created_at"
+    t.index ["trend_slug"], name: "index_trend_run_histories_on_trend_slug"
   end
 
   create_table "trends", force: :cascade do |t|


### PR DESCRIPTION
### Motivation
- CI runs were failing with `ActiveRecord::PendingMigrationError` for migration `20260419073000_create_trend_run_histories.rb`, which blocks specs from loading the test schema.
- The intent is to ensure `db:schema:load` used in test/CI environments reflects the new table so tests no longer see pending migrations.

### Description
- Bumped `ActiveRecord::Schema` version in `db/schema.rb` to `2026_04_19_073000` to match the migration timestamp.
- Added a `trend_run_histories` table definition with columns `trend`, `trend_slug`, `published`, and standard timestamps to `db/schema.rb`.
- Added indexes on `trend_slug` and `created_at` in the schema so `db:schema:load` recreates those indexes in fresh test databases.

### Testing
- CI RSpec run previously failed due to the pending migration error, which this change addresses (CI failure observed: `ActiveRecord::PendingMigrationError`).
- Attempted to run `bundle exec rails db:migrate` locally but the environment lacks Bundler (`bundle: command not found`), so migration execution could not be verified here.
- Attempted `bin/rails db:migrate` locally but the environment lacks Ruby (`ruby: No such file or directory`), so no automated tests or migrations were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae1a62ba4832fb79269e40316412e)