### PR TITLE
Fix short-content logging in AI article creator and add TrendRunHistory table and specs

### DIFF
--- a/app/services/ai/community_bot_trending_article_creator.rb
+++ b/app/services/ai/community_bot_trending_article_creator.rb
@@ -282,7 +282,7 @@ module Ai
       Rails.logger.info("Ai::CommunityBotTrendingArticleCreator: Generated #{word_count} words for '#{title}'")
       min_words = (@target_word_count * 0.6).to_i
       if word_count < min_words
-        Rails.logger.warn("Ai::CommunityBotTrendingArticleCreator: Article below minimum word count (#{word_count}/#{MIN_WORD_COUNT})")
+        Rails.logger.warn("Ai::CommunityBotTrendingArticleCreator: Article below minimum word count (#{word_count}/#{min_words})")
       end
 
       log_engagement_signals(markdown)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_19_073000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1687,6 +1687,16 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
     t.index ["social_preview_template"], name: "index_tags_on_social_preview_template"
     t.index ["supported"], name: "index_tags_on_supported"
     t.index ["taggings_count"], name: "index_tags_on_taggings_count"
+  end
+
+  create_table "trend_run_histories", force: :cascade do |t|
+    t.string "trend", null: false
+    t.string "trend_slug", null: false
+    t.boolean "published", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_trend_run_histories_on_created_at"
+    t.index ["trend_slug"], name: "index_trend_run_histories_on_trend_slug"
   end
 
   create_table "trends", force: :cascade do |t|

--- a/spec/models/trend_run_history_spec.rb
+++ b/spec/models/trend_run_history_spec.rb
@@ -1,12 +1,30 @@
 require "rails_helper"
 
 RSpec.describe TrendRunHistory do
+  describe ".clean" do
+    it "normalizes surrounding and repeated whitespace" do
+      expect(described_class.clean("  up   board   result  ")).to eq("up board result")
+    end
+  end
+
   describe ".slugify" do
     it "returns a deterministic fallback slug for non-latin trends" do
       slug = described_class.slugify("शिखा वर्मा")
 
       expect(slug).to start_with("trend-")
       expect(slug.length).to eq(18)
+    end
+  end
+
+  describe ".fresh?" do
+    it "returns false when the slug was used within the cooldown window" do
+      described_class.create!(trend: "UP Board", trend_slug: "up-board", published: true)
+
+      expect(described_class.fresh?("up-board", 48)).to be(false)
+    end
+
+    it "returns true when the slug has not been used in the cooldown window" do
+      expect(described_class.fresh?("brand-new-trend", 48)).to be(true)
     end
   end
 end

--- a/spec/services/ai/community_bot_trending_article_creator_spec.rb
+++ b/spec/services/ai/community_bot_trending_article_creator_spec.rb
@@ -127,5 +127,22 @@ RSpec.describe Ai::CommunityBotTrendingArticleCreator do
       expect(result.body).to include("[upresults.nic.in](https://upresults.nic.in)")
       expect(result.body).to include("[https://upmsp.edu.in](https://upmsp.edu.in)")
     end
+
+    it "logs a short-content warning without raising errors" do
+      service = described_class.new(ai_context: "Career platform", target_word_count: 800)
+      response = {
+        title: "Quick update",
+        markdown: "too short",
+        description: "desc",
+        tags: %w[results education jobs career]
+      }.to_json
+
+      allow(Rails.logger).to receive(:warn)
+
+      result = service.send(:parse_response, response, [], [])
+
+      expect(result).to be_present
+      expect(Rails.logger).to have_received(:warn).with(include("Article below minimum word count (2/480)"))
+    end
   end
 end


### PR DESCRIPTION
### Motivation
- Ensure the AI-generated article creator logs the correct minimum-word threshold when content is too short.
- Persist recent trend runs and validate slug/cooldown behavior via tests to avoid reusing trends too quickly.

### Description
- Updated the warning in `Ai::CommunityBotTrendingArticleCreator#parse_response` to reference the calculated `min_words` instead of the `MIN_WORD_COUNT` constant.
- Added a `trend_run_histories` table to `db/schema.rb` with `trend`, `trend_slug`, `published`, timestamps, and relevant indexes.
- Added `spec/models/trend_run_history_spec.rb` covering `.clean`, `.slugify`, and `.fresh?` behaviors.
- Extended `spec/services/ai/community_bot_trending_article_creator_spec.rb` with a test that asserts a short-content warning is logged without raising errors.

### Testing
- Ran `bundle exec rspec spec/services/ai/community_bot_trending_article_creator_spec.rb` and the updated service specs passed.
- Ran `bundle exec rspec spec/models/trend_run_history_spec.rb` and the new model specs passed.
- Ran the modified specs together and they succeeded with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae1a62ba4832fb79269e40316412e)