### PR TITLE
Use direct Razorpay JSON API (HTTParty) for subscription creation and add robust error handling

### DIFF
--- a/app/controllers/razorpay_subscriptions_controller.rb
+++ b/app/controllers/razorpay_subscriptions_controller.rb
@@ -35,12 +35,12 @@ class RazorpaySubscriptionsController < ApplicationController
     Rails.logger.info "[Razorpay Debug] Plan ID configured: #{plan_id.inspect}"
     Rails.logger.info "[Razorpay Debug] Sending Payload: #{payload.to_json}"
 
-    subscription = Razorpay::Subscription.create(payload)
+    subscription = create_razorpay_subscription(payload)
 
-    Rails.logger.info "[Razorpay Debug] Success! Subscription ID: #{subscription.id}"
+    Rails.logger.info "[Razorpay Debug] Success! Subscription ID: #{subscription.fetch("id")}"
     Rails.logger.info "[Razorpay Debug] ----------------------------------------"
 
-    @subscription_id = subscription.id
+    @subscription_id = subscription.fetch("id")
     @razorpay_key_id = Settings::General.razorpay_key_id
     @user = current_user
     @plan_id = plan_id
@@ -142,8 +142,36 @@ class RazorpaySubscriptionsController < ApplicationController
 
   private
 
+  def create_razorpay_subscription(payload)
+    response = HTTParty.post(
+      "https://api.razorpay.com/v1/subscriptions",
+      basic_auth: {
+        username: Settings::General.razorpay_key_id,
+        password: Settings::General.razorpay_key_secret,
+      },
+      body: payload.to_json,
+      headers: { "Content-Type" => "application/json" },
+      timeout: 10,
+    )
+
+    parsed_response = response.parsed_response.presence || JSON.parse(response.body)
+    return parsed_response if response.success?
+
+    error_message = razorpay_error_message(parsed_response, response.body)
+    raise Razorpay::Error, error_message
+  rescue JSON::ParserError => e
+    raise Razorpay::Error, "Unable to parse Razorpay subscription response: #{e.message}"
+  rescue HTTParty::Error, SocketError, Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
+    raise Razorpay::Error, "Unable to reach Razorpay subscriptions API: #{e.message}"
+  end
+
+  def razorpay_error_message(parsed_response, raw_body)
+    return raw_body unless parsed_response.is_a?(Hash)
+
+    parsed_response.dig("error", "description") || parsed_response["error"] || raw_body
+  end
+
   def initialize_razorpay
     Razorpay.setup(Settings::General.razorpay_key_id, Settings::General.razorpay_key_secret)
-    Razorpay.headers = { "Content-Type" => "application/json" }
   end
 end

--- a/spec/requests/razorpay_subscriptions_spec.rb
+++ b/spec/requests/razorpay_subscriptions_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe "RazorpaySubscriptions" do
   let(:razorpay_key_secret) { "rzp_test_secret456" }
   let(:plan_id) { "plan_test123" }
 
+  def razorpay_response(success:, body:)
+    response_class = Class.new do
+      def initialize(success, body)
+        @success = success
+        @body = body
+      end
+
+      attr_reader :body
+
+      def success?
+        @success
+      end
+
+      def parsed_response
+        JSON.parse(body)
+      end
+    end
+
+    response_class.new(success, body.to_json)
+  end
+
   before do
     allow(Settings::General).to receive(:razorpay_key_id).and_return(razorpay_key_id)
     allow(Settings::General).to receive(:razorpay_key_secret).and_return(razorpay_key_secret)
@@ -28,28 +49,33 @@ RSpec.describe "RazorpaySubscriptions" do
 
       after { ENV.delete("RAZORPAY_PLAN_ID") }
 
-      it "creates a Razorpay subscription and renders the new page" do
-        subscription_double = double("Razorpay::Subscription", id: "sub_test789")
-        allow(Razorpay::Subscription).to receive(:create).and_return(subscription_double)
+      it "creates a Razorpay subscription with a JSON API request and renders the new page" do
+        allow(HTTParty).to receive(:post).and_return(
+          razorpay_response(success: true, body: { "id" => "sub_test789" }),
+        )
 
         get new_razorpay_subscription_path
 
-        expect(Razorpay::Subscription).to have_received(:create).with(
-          hash_including(plan_id: plan_id, quantity: 1),
-          )
+        expect(HTTParty).to have_received(:post) do |url, options|
+          expect(url).to eq("https://api.razorpay.com/v1/subscriptions")
+          expect(options[:basic_auth]).to eq(username: razorpay_key_id, password: razorpay_key_secret)
+          expect(options[:headers]).to eq("Content-Type" => "application/json")
+          expect(JSON.parse(options[:body])).to include("plan_id" => plan_id, "quantity" => 1)
+        end
         expect(response).to have_http_status(:ok)
       end
 
       it "uses plan param when provided" do
         custom_plan = "plan_custom456"
-        subscription_double = double("Razorpay::Subscription", id: "sub_test789")
-        allow(Razorpay::Subscription).to receive(:create).and_return(subscription_double)
+        allow(HTTParty).to receive(:post).and_return(
+          razorpay_response(success: true, body: { "id" => "sub_test789" }),
+        )
 
         get new_razorpay_subscription_path, params: { plan: custom_plan }
 
-        expect(Razorpay::Subscription).to have_received(:create).with(
-          hash_including(plan_id: custom_plan),
-          )
+        expect(HTTParty).to have_received(:post) do |_url, options|
+          expect(JSON.parse(options[:body])).to include("plan_id" => custom_plan)
+        end
       end
 
       it "redirects with error when no plan is configured" do
@@ -62,9 +88,9 @@ RSpec.describe "RazorpaySubscriptions" do
       end
 
       it "handles Razorpay API errors gracefully" do
-        allow(Razorpay::Subscription).to receive(:create).and_raise(
-          Razorpay::Error.new("API error"),
-          )
+        allow(HTTParty).to receive(:post).and_return(
+          razorpay_response(success: false, body: { "error" => { "description" => "API error" } }),
+        )
 
         get new_razorpay_subscription_path
 


### PR DESCRIPTION
### Motivation

- Replace usage of the Razorpay SDK `Subscription.create` call with a direct JSON API request to improve reliability, control, and timeout handling. 
- Surface clearer error messages from Razorpay responses and handle network/JSON parse errors explicitly. 
- Ensure subscription IDs are read from the parsed JSON response consistently.

### Description

- Add a private `create_razorpay_subscription(payload)` method that calls `HTTParty.post` to `https://api.razorpay.com/v1/subscriptions` with `basic_auth`, JSON `body`, `Content-Type: application/json` header and a `timeout` of 10 seconds. 
- Parse the HTTP response, return the parsed JSON on success, and raise `Razorpay::Error` with a helpful message on API errors, parse failures, or network/timeouts; implement `razorpay_error_message` helper to extract error descriptions. 
- Update `new` action to call `create_razorpay_subscription` and use `subscription.fetch("id")` (and set `@subscription_id`) instead of calling `subscription.id`. 
- Remove the previous `Razorpay.headers = { "Content-Type" => "application/json" }` assignment from `initialize_razorpay`. 
- Update request specs to stub `HTTParty.post` via a new `razorpay_response` test helper and adjust expectations to assert the JSON API call, auth, headers, and payload, including error-case simulation.

### Testing

- Ran the modified request spec `spec/requests/razorpay_subscriptions_spec.rb` with the updated HTTParty mocks and the tests passed. 
- The updated specs exercise success and error paths for subscription creation and confirm the controller renders or redirects as expected. 
- No external Razorpay API calls were made during tests due to mocked `HTTParty.post` responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32785af214832fa45d5f901363dd2d)