### PR TITLE
Introduce free CP++ trial and require CP++ access for mock exams; update UI and policies

### DIFF
--- a/app/controllers/mock_exam_attempts_controller.rb
+++ b/app/controllers/mock_exam_attempts_controller.rb
@@ -5,17 +5,15 @@ class MockExamAttemptsController < ApplicationController
 
   def create
     unless policy(MockExamAttempt).create?
-      resets_at = Time.current.end_of_day.iso8601
-      msg = "You've used your free attempt for today. Upgrade to Premium for unlimited mock exams."
+      msg = mock_exam_access_denied_message
       respond_to do |format|
         format.html { redirect_to mock_exam_path(slug: @template.slug), alert: msg }
         format.json do
           render json: {
-            error: "daily_limit_reached",
+            error: "mock_exam_access_required",
             message: msg,
             is_premium: current_user.cached_base_subscriber?,
             upgrade_url: Settings::General.razorpay_key_id.present? ? new_razorpay_subscription_path : new_stripe_subscription_path,
-            resets_at: resets_at,
           }, status: :forbidden
         end
       end
@@ -124,6 +122,10 @@ class MockExamAttemptsController < ApplicationController
   end
 
   private
+
+  def mock_exam_access_denied_message
+    "Start your free CP++ trial or subscribe to access mock exams."
+  end
 
   def set_template
     @template = MockExamTemplate.find_by!(slug: params[:mock_exam_slug], active: true, published: true)

--- a/app/controllers/mock_exams_controller.rb
+++ b/app/controllers/mock_exams_controller.rb
@@ -35,7 +35,7 @@ class MockExamsController < ApplicationController
           followed_tags: followed,
           user_signed_in: current_user.present?,
           is_premium: current_user&.cached_base_subscriber? || false,
-          daily_attempts_remaining: premium_attempts_remaining,
+          trial_attempts_remaining: premium_attempts_remaining,
           upgrade_url: premium_upgrade_url,
         }
       end
@@ -54,8 +54,7 @@ class MockExamsController < ApplicationController
           can_attempt: can_attempt?,
           user_signed_in: current_user.present?,
           is_premium: current_user&.cached_base_subscriber? || false,
-          daily_attempts_remaining: premium_attempts_remaining,
-          daily_limit: current_user&.cached_base_subscriber? ? nil : MockExamAttemptPolicy::DAILY_FREE_LIMIT,
+          trial_attempts_remaining: premium_attempts_remaining,
           upgrade_url: premium_upgrade_url,
           )
       end
@@ -164,7 +163,7 @@ class MockExamsController < ApplicationController
           section_accuracy: build_section_accuracy(attempts),
           attempts: attempts.map { |a| dashboard_attempt_json(a) },
           is_premium: current_user.cached_base_subscriber?,
-          daily_attempts_remaining: policy.daily_attempts_remaining,
+          trial_attempts_remaining: policy.daily_attempts_remaining,
           upgrade_url: Settings::General.razorpay_key_id.present? ? new_razorpay_subscription_path : new_stripe_subscription_path
         }
       end
@@ -316,8 +315,6 @@ class MockExamsController < ApplicationController
 
   def can_attempt?
     return false unless current_user
-    return true if current_user.cached_base_subscriber?
-
     policy = MockExamAttemptPolicy.new(current_user, MockExamAttempt)
     policy.create?
   rescue Pundit::NotAuthorizedError
@@ -326,8 +323,6 @@ class MockExamsController < ApplicationController
 
   def premium_attempts_remaining
     return nil unless current_user
-    return nil if current_user.cached_base_subscriber?
-
     policy = MockExamAttemptPolicy.new(current_user, MockExamAttempt)
     policy.daily_attempts_remaining
   end

--- a/app/controllers/razorpay_subscriptions_controller.rb
+++ b/app/controllers/razorpay_subscriptions_controller.rb
@@ -102,6 +102,24 @@ class RazorpaySubscriptionsController < ApplicationController
     redirect_to user_settings_path(:billing)
   end
 
+  # POST /razorpay_subscriptions/free_trial
+  # Grants CP++ trial access without collecting payment details.
+  def free_trial
+    if current_user.cached_base_subscriber?
+      flash[:notice] = "You already have CP++ access."
+      redirect_to user_settings_path(:billing) and return
+    end
+
+    current_user.add_role("base_subscriber")
+    current_user.update!(current_subscriber_status: :trial_subscription)
+    current_user.touch
+    current_user.profile&.touch
+    NotifyMailer.with(user: current_user).base_subscriber_role_email.deliver_later
+
+    flash[:notice] = "Your free CP++ trial is active. You now have unlimited mock exam access."
+    redirect_to user_settings_path(:billing)
+  end
+
   # GET /razorpay_subscriptions/:id/edit
   # Shows subscription management page
   def edit

--- a/app/javascript/mockExams/MockExamDetail.jsx
+++ b/app/javascript/mockExams/MockExamDetail.jsx
@@ -57,11 +57,11 @@ export function MockExamDetail({ slug }) {
         window.location.href = goFullscreen ? `${url}?fs=1` : url;
       } else {
         const errData = await res.json();
-        if (errData.error === 'daily_limit_reached') {
+        if (['daily_limit_reached', 'mock_exam_access_required'].includes(errData.error)) {
           setTemplate(prev => ({
             ...prev,
             can_attempt: false,
-            daily_attempts_remaining: 0,
+            trial_attempts_remaining: 0,
             upgrade_url: errData.upgrade_url,
           }));
           setShowInstructions(false);
@@ -131,17 +131,15 @@ export function MockExamDetail({ slug }) {
               <div>
                 {t.can_attempt ? (
                   <p class="fw-bold fs-s" style={{ color: 'var(--accent-brand)' }}>
-                    {t.daily_attempts_remaining === 1
-                      ? '1 free attempt remaining today'
-                      : `${t.daily_attempts_remaining} free attempts remaining today`}
+                    Start a free trial or subscribe to access mock exams
                   </p>
                 ) : (
                   <p class="fw-bold fs-s" style={{ color: 'var(--accent-danger)' }}>
-                    Daily free attempt used
+                    Start a free trial or subscribe to access mock exams
                   </p>
                 )}
                 <p class="fs-s color-secondary mt-1">
-                  Upgrade to Premium for unlimited mock exam attempts
+                  Start a free trial or subscribe for CP++ mock exam access
                 </p>
               </div>
               {t.upgrade_url && (

--- a/app/javascript/mockExams/UserMockExamDashboard.jsx
+++ b/app/javascript/mockExams/UserMockExamDashboard.jsx
@@ -72,12 +72,10 @@ export function UserMockExamDashboard() {
           <div class="flex items-center justify-between flex-wrap gap-3">
             <div>
               <p class="fw-bold fs-s" style={{ color: 'var(--accent-brand)' }}>
-                {data.daily_attempts_remaining != null && data.daily_attempts_remaining > 0
-                  ? `${data.daily_attempts_remaining} free attempt${data.daily_attempts_remaining === 1 ? '' : 's'} remaining today`
-                  : 'Daily free attempt used'}
+                Start a free trial or subscribe to access mock exams
               </p>
               <p class="fs-s color-secondary mt-1">
-                Upgrade to Premium for unlimited mock exams, and more
+                Start a free trial or subscribe for CP++ mock exam access
               </p>
             </div>
             <a href={data.upgrade_url} class="c-btn c-btn--primary"

--- a/app/policies/mock_exam_attempt_policy.rb
+++ b/app/policies/mock_exam_attempt_policy.rb
@@ -1,11 +1,7 @@
 class MockExamAttemptPolicy < ApplicationPolicy
-  DAILY_FREE_LIMIT = 1
-
   def create?
     require_user_in_good_standing!
-    return true if user.cached_base_subscriber?
-
-    daily_attempts_used < DAILY_FREE_LIMIT
+    user.cached_base_subscriber?
   end
 
   def show?
@@ -23,7 +19,7 @@ class MockExamAttemptPolicy < ApplicationPolicy
   def daily_attempts_remaining
     return nil if user.cached_base_subscriber?
 
-    [DAILY_FREE_LIMIT - daily_attempts_used, 0].max
+    0
   end
 
   class Scope < Scope
@@ -34,11 +30,5 @@ class MockExamAttemptPolicy < ApplicationPolicy
         scope.where(user: user)
       end
     end
-  end
-
-  private
-
-  def daily_attempts_used
-    user.mock_exam_attempts.where("created_at >= ?", Time.current.beginning_of_day).count
   end
 end

--- a/app/views/users/_billing.html.erb
+++ b/app/views/users/_billing.html.erb
@@ -3,7 +3,7 @@
     <%= t("views.settings.billing.heading") %>
   </h2>
 
-  <% if current_user.stripe_id_code.present? && current_user.cached_base_subscriber? %>
+  <% if current_user.cached_base_subscriber? %>
     <div class="crayons-notice crayons-notice--info mb-4" role="alert">
       <p>
         <strong><%= t("views.settings.billing.current_status") %>:</strong>
@@ -18,19 +18,29 @@
   <% end %>
 
   <% if Settings::General.razorpay_key_id.present? %>
-    <% if current_user.cached_base_subscriber? %>
+    <% if current_user.cached_base_subscriber? && current_user.stripe_id_code.present? %>
       <div class="mb-4">
         <a href="<%= edit_razorpay_subscription_path("me") %>" class="crayons-btn crayons-btn--secondary" data-no-instant>
           Manage <%= community_name %> Premium Subscription
         </a>
       </div>
-    <% else %>
+    <% elsif current_user.cached_base_subscriber? %>
       <div class="mb-4">
-        <p class="mb-2">Subscribe to <%= community_name %> Premium to unlock exclusive features.</p>
+        <p class="mb-2">Your free CP++ trial is active with unlimited mock exam access. Subscribe to keep CP++ access.</p>
         <a href="<%= new_razorpay_subscription_path %>" class="crayons-btn" data-no-instant>
           Subscribe Now
         </a>
-        <p class="fs-s color-base-60 mt-2">Supports UPI, Cards, NetBanking, and Wallets via Razorpay.</p>
+      </div>
+    <% else %>
+      <div class="mb-4">
+        <p class="mb-2">Subscribe to <%= community_name %> Premium to unlock exclusive features.</p>
+        <div class="flex gap-2 fw-wrap">
+          <%= button_to "Start Free Trial", free_trial_razorpay_subscriptions_path, method: :post, class: "crayons-btn crayons-btn--secondary" %>
+          <a href="<%= new_razorpay_subscription_path %>" class="crayons-btn" data-no-instant>
+            Subscribe Now
+          </a>
+        </div>
+        <p class="fs-s color-base-60 mt-2">Start a CP++ trial without a debit card, or subscribe with UPI, Cards, NetBanking, and Wallets via Razorpay.</p>
       </div>
     <% end %>
   <% elsif current_user.stripe_id_code.blank? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,6 +242,7 @@ Rails.application.routes.draw do
     resources :razorpay_subscriptions, only: %i[new edit destroy] do
       collection do
         get :confirm
+        post :free_trial
       end
     end
     get "/++", to: redirect("/razorpay_subscriptions/new")

--- a/spec/policies/mock_exam_attempt_policy_spec.rb
+++ b/spec/policies/mock_exam_attempt_policy_spec.rb
@@ -12,27 +12,37 @@ RSpec.describe MockExamAttemptPolicy, type: :policy do
   context "when user is signed in" do
     let(:user) { create(:user) }
 
-    context "when user has no attempts today" do
-      it { is_expected.to permit_actions(%i[create]) }
-    end
-
-    context "when user has used their daily free attempt" do
-      before do
-        template = create(:mock_exam_template)
-        create(:mock_exam_attempt, user: user, mock_exam_template: template, created_at: Time.current)
-      end
-
+    context "when user has no CP++ access" do
       it { is_expected.to forbid_actions(%i[create]) }
     end
 
-    context "when user is a premium subscriber" do
+    context "when user has an active free trial" do
       before do
         user.add_role("base_subscriber")
+        user.update!(current_subscriber_status: :trial_subscription)
       end
 
       it { is_expected.to permit_actions(%i[create]) }
 
-      context "when they have already used multiple attempts today" do
+      context "when they have already used multiple attempts" do
+        before do
+          template = create(:mock_exam_template)
+          3.times { create(:mock_exam_attempt, user: user, mock_exam_template: template, created_at: Time.current) }
+        end
+
+        it { is_expected.to permit_actions(%i[create]) }
+      end
+    end
+
+    context "when user is a paying premium subscriber" do
+      before do
+        user.add_role("base_subscriber")
+        user.update!(current_subscriber_status: :paying_subscription)
+      end
+
+      it { is_expected.to permit_actions(%i[create]) }
+
+      context "when they have already used multiple attempts" do
         before do
           template = create(:mock_exam_template)
           3.times { create(:mock_exam_attempt, user: user, mock_exam_template: template, created_at: Time.current) }
@@ -53,39 +63,31 @@ RSpec.describe MockExamAttemptPolicy, type: :policy do
     let(:user) { create(:user) }
     let(:policy) { described_class.new(user, MockExamAttempt) }
 
-    context "when user is a premium subscriber" do
-      before { user.add_role("base_subscriber") }
-
-      it "returns nil" do
-        expect(policy.daily_attempts_remaining).to be_nil
-      end
-    end
-
-    context "when user has no attempts today" do
-      it "returns the daily free limit" do
-        expect(policy.daily_attempts_remaining).to eq(described_class::DAILY_FREE_LIMIT)
-      end
-    end
-
-    context "when user has used their daily free attempt" do
-      before do
-        template = create(:mock_exam_template)
-        create(:mock_exam_attempt, user: user, mock_exam_template: template, created_at: Time.current)
-      end
-
+    context "when user has no CP++ access" do
       it "returns 0" do
         expect(policy.daily_attempts_remaining).to eq(0)
       end
     end
 
-    context "when user's attempts were from yesterday" do
+    context "when user has an active free trial" do
       before do
-        template = create(:mock_exam_template)
-        create(:mock_exam_attempt, user: user, mock_exam_template: template, created_at: 1.day.ago)
+        user.add_role("base_subscriber")
+        user.update!(current_subscriber_status: :trial_subscription)
       end
 
-      it "returns the daily free limit (resets daily)" do
-        expect(policy.daily_attempts_remaining).to eq(described_class::DAILY_FREE_LIMIT)
+      it "returns nil for unlimited attempts" do
+        expect(policy.daily_attempts_remaining).to be_nil
+      end
+    end
+
+    context "when user is a paying premium subscriber" do
+      before do
+        user.add_role("base_subscriber")
+        user.update!(current_subscriber_status: :paying_subscription)
+      end
+
+      it "returns nil for unlimited attempts" do
+        expect(policy.daily_attempts_remaining).to be_nil
       end
     end
   end

--- a/spec/requests/razorpay_subscriptions_spec.rb
+++ b/spec/requests/razorpay_subscriptions_spec.rb
@@ -177,6 +177,40 @@ RSpec.describe "RazorpaySubscriptions" do
     end
   end
 
+
+  describe "POST /razorpay_subscriptions/free_trial" do
+    context "when the user is not signed in" do
+      it "redirects to the sign in page" do
+        post free_trial_razorpay_subscriptions_path
+        expect(response).to redirect_to("/magic_links/new")
+      end
+    end
+
+    context "when the user is signed in" do
+      before { sign_in user }
+
+      it "grants CP++ trial access without a payment method" do
+        post free_trial_razorpay_subscriptions_path
+
+        user.reload
+        expect(user.roles.pluck(:name)).to include("base_subscriber")
+        expect(user.current_subscriber_status).to eq("trial_subscription")
+        expect(user.stripe_id_code).to be_nil
+        expect(response).to redirect_to(user_settings_path(:billing))
+      end
+
+      it "does not change existing subscribers" do
+        user.add_role("base_subscriber")
+        user.update!(current_subscriber_status: :paying_subscription, stripe_id_code: "sub_test789")
+
+        post free_trial_razorpay_subscriptions_path
+
+        expect(user.reload.current_subscriber_status).to eq("paying_subscription")
+        expect(user.stripe_id_code).to eq("sub_test789")
+      end
+    end
+  end
+
   describe "GET /razorpay_subscriptions/:id/edit" do
     context "when the user is not signed in" do
       it "redirects to the sign in page" do


### PR DESCRIPTION
### Motivation
- Move mock exam access from a per-day free-attempt model to an explicit CP++ subscriber/trial model so users get an unlimited trial and clearer upgrade path.
- Surface a one-click trial flow in the billing UI and replace daily-attempt messaging with trial/subscription messaging.

### Description
- Require CP++ access for starting mock exams by making `MockExamAttemptPolicy#create?` require `user.cached_base_subscriber?` and remove the daily free-attempt limit logic and constants.
- Add a `free_trial` controller action at `RazorpaySubscriptionsController#free_trial` and a `POST /razorpay_subscriptions/free_trial` route to grant a trial without payment, update user roles/status, touch profile, and send notification email.
- Update mock exam controllers and JSON payloads to use the new error key `mock_exam_access_required`, replace `daily_attempts_remaining` with `trial_attempts_remaining`, and centralize the access-denied message via `mock_exam_access_denied_message`.
- Update React components `MockExamDetail.jsx` and `UserMockExamDashboard.jsx` to change copy to trial/subscription messaging and handle the new error key and `trial_attempts_remaining` field.
- Update billing partial `users/_billing.html.erb` to show trial CTA (including a `Start Free Trial` button) and adjust subscription management links depending on `stripe_id_code` presence.
- Adjust specs to reflect the new subscription/trial behavior in `spec/policies/mock_exam_attempt_policy_spec.rb` and add request tests for the new `free_trial` endpoint in `spec/requests/razorpay_subscriptions_spec.rb`.

### Testing
- Ran the updated policy spec `rspec spec/policies/mock_exam_attempt_policy_spec.rb`, which passed for the new subscriber/trial behavior.
- Ran the updated request spec `rspec spec/requests/razorpay_subscriptions_spec.rb`, which passed including `POST /razorpay_subscriptions/free_trial` scenarios for signed-in and anonymous users.
- Ran the modified spec files together via `bundle exec rspec` for the touched areas and observed all modified tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32974c6cc88326a1ebcb0ae29e7816)